### PR TITLE
Joshc slac/message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ More to come.
 * `make test_verbose` - runs tests in test directory and prints stdout
 * `make update_beams` - updates the locally install `beams` package
 * `make flake8` - flake check source files
+
+## Hanging TODOs:
+- make a decorator for work functions in beams/sequencer/Worker.py that logs PID

--- a/beams/sequencer/SequenceServer.py
+++ b/beams/sequencer/SequenceServer.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 import logging
 import time
+import os
 
 from multiprocessing import Queue
 
@@ -41,14 +42,15 @@ class SequenceServer(SequencerServicer, Worker):
     return CommandReply(**self.sequencer_state.get_command_reply())
 
   def work_func(self):
-      port = "50051"
-      add_SequencerServicer_to_server(self, self.server)
-      self.server.add_insecure_port("[::]:" + port)
-      self.server.start()
-      print("Server started, listening on " + port)
-      while (self.do_work.value):
-        time.sleep(1)
-      print("exitted")
+    print(f"{self.proc_name} running on pid: {os.getpid()}")
+    port = "50051"
+    add_SequencerServicer_to_server(self, self.server)
+    self.server.add_insecure_port("[::]:" + port)
+    self.server.start()
+    print("Server started, listening on " + port)
+    while (self.do_work.value):
+      time.sleep(1)
+    print("exitted")
 
 
 if __name__ == "__main__":

--- a/beams/sequencer/Sequencer.py
+++ b/beams/sequencer/Sequencer.py
@@ -1,5 +1,5 @@
 import time
-from multiprocessing import Process, Queue
+import os
 
 from beams.sequencer.helpers.Worker import Worker
 from beams.sequencer.SequencerState import SequencerState, SequencerStateVariable
@@ -11,22 +11,9 @@ class Sequencer(Worker):
     super().__init__("Sequencer")
     # state maintenece object
     self.state = SequencerState() 
-    
-    # GRPC server object
-    self.sequence_server = SequenceServer(self.state)
-    self.sequence_server.start_work() # TODO: move to work thread
 
-    # Message Handler thread
-    self.message_handler_proc = Process(target=self.message_thread)
-
-  def message_thread(self):
-
-
-
-  def work_func(self):
-    # spawn message handling thread
-
-
+  def message_thread(self, worker_ref):
+    print(f"{self.proc_name} running on pid: {os.getpid()}")
     while (self.do_work.value):
       if (self.sequence_server.run_state_change_queue.qsize() != 0):
         mess = self.sequence_server.run_state_change_queue.get()
@@ -34,6 +21,17 @@ class Sequencer(Worker):
       elif (self.sequence_server.sequence_request_queue.qsize() != 0):
         pass
       time.sleep(.1)
+
+  def work_func(self):
+    print(f"{self.proc_name} running on pid: {os.getpid()}")
+    # GRPC server object
+    self.sequence_server = SequenceServer(self.state)
+    self.sequence_server.start_work()  # TODO: move to work thread
+    # Message Handler thread
+    self.message_worker = Worker("message_handler", work_func=self.message_thread)
+    self.message_worker.start_work() 
+    # spawn message handling thread
+    pass
 
 
 if __name__ == "__main__":

--- a/beams/sequencer/Sequencer.py
+++ b/beams/sequencer/Sequencer.py
@@ -1,4 +1,5 @@
 import time
+from multiprocessing import Process, Queue
 
 from beams.sequencer.helpers.Worker import Worker
 from beams.sequencer.SequencerState import SequencerState, SequencerStateVariable
@@ -8,11 +9,24 @@ from beams.sequencer.SequenceServer import SequenceServer
 class Sequencer(Worker):
   def __init__(self):
     super().__init__("Sequencer")
+    # state maintenece object
     self.state = SequencerState() 
+    
+    # GRPC server object
     self.sequence_server = SequenceServer(self.state)
-    self.sequence_server.start_work()
+    self.sequence_server.start_work() # TODO: move to work thread
+
+    # Message Handler thread
+    self.message_handler_proc = Process(target=self.message_thread)
+
+  def message_thread(self):
+
+
 
   def work_func(self):
+    # spawn message handling thread
+
+
     while (self.do_work.value):
       if (self.sequence_server.run_state_change_queue.qsize() != 0):
         mess = self.sequence_server.run_state_change_queue.get()

--- a/beams/sequencer/helpers/PriorityQueue.py
+++ b/beams/sequencer/helpers/PriorityQueue.py
@@ -1,0 +1,32 @@
+"""
+Thread safe priority queue
+Warning this is not effecient to search, it is a dumb priority queue. If performance becomes an issue... this is python.
+But also make it a binary tree, you could utilize the heapq library but it kind of sucks
+"""
+
+import heapq
+from multiprocessing import Lock
+
+
+class PriorityQueue:
+  def __init__(self, priority_dict):
+    self.__queue__ = []
+    self.__priority_dict__ = priority_dict
+    self.__lock__ = Lock()
+    self.entry_count = 0
+
+  def get_priority_int(self, prio_enum):
+    try:
+      return self.__priority_dict__[prio_enum]
+    except KeyError:
+      raise KeyError(f"Priority Enum provided {prio_enum} not in priority_dict")
+
+  def put(self, ent, prio_enum):
+    with self.__lock__:
+      heapq.heappush(self.__queue__, (self.get_priority_int(prio_enum), 
+                                      self.entry_count, 
+                                      ent))
+      self.entry_count += 1
+
+  def pop(self):
+    return heapq.heappop(self.__queue__)[-1]

--- a/beams/sequencer/helpers/Worker.py
+++ b/beams/sequencer/helpers/Worker.py
@@ -13,7 +13,8 @@ import time
 class Worker():
   def __init__(self, proc_name, stop_func=None):
     self.do_work = Value('i', False)
-    self.work_proc = Process(target=self.work_func, name=proc_name)
+    self.proc_name = proc_name
+    self.work_proc = Process(target=self.work_func, name=self.proc_name)
     self.stop_func = stop_func
 
   def start_work(self):
@@ -46,6 +47,10 @@ class Worker():
     logging.info(f"Work thread: {self.work_proc.pid} exit")
     '''
     raise NotImplementedError("Implement a work function in the child class!")
+
+  def set_work_func(self, work_func):
+    self.work_func = work_func
+    self.work_proc = Process(target=self.work_func, name=self.proc_name, args=(self,))
 
 
 if __name__ == "__main__":

--- a/beams/sequencer/helpers/Worker.py
+++ b/beams/sequencer/helpers/Worker.py
@@ -1,7 +1,6 @@
 import logging
 from multiprocessing import Process, Value
 import time
-
 """
 * An base class for child classes whos main function is to support a work thread.
 * Holds volatile `self.do_work` which is intended to handle kill signal
@@ -11,10 +10,15 @@ import time
 
 
 class Worker():
-  def __init__(self, proc_name, stop_func=None):
+  def __init__(self, proc_name, stop_func=None, work_func=None):
     self.do_work = Value('i', False)
     self.proc_name = proc_name
-    self.work_proc = Process(target=self.work_func, name=self.proc_name)
+    # TODO: we may want to decorate work func so it prints proc id...
+    if (work_func is None):
+      self.work_proc = Process(target=self.work_func, name=self.proc_name)
+    else:
+      self.work_func = work_func
+      self.work_proc = Process(target=self.work_func, name=self.proc_name, args=(self,))
     self.stop_func = stop_func
 
   def start_work(self):

--- a/beams/sequencer/remote_calls/sequencer.proto
+++ b/beams/sequencer/remote_calls/sequencer.proto
@@ -3,10 +3,7 @@ syntax = "proto3";
 // Sequencer Service Definition
 service Sequencer {
   // Enqueue a sequence command of varying priority
-  rpc EnqueueSequence (SequenceCommand) returns (CommandReply) {}
-  
-  // Command a change in run paradigm of the program
-  rpc ChangeRunState (AlterState) returns (CommandReply) {}
+  rpc EnqueueCommand (GenericCommand) returns (CommandReply) {}
 
   // Heart beat message for clients
   rpc RequestHeartBeat(Empty) returns (CommandReply) {}
@@ -45,7 +42,7 @@ enum TickStatus {
   FAILURE = 3;
 }
 
-// For when we use a real programming language.
+// For when we use a real programming language
 message GenericMessage {
   MessageType mess_t = 1;
 }
@@ -60,6 +57,14 @@ message AlterState{
   MessageType mess_t = 1;
   RunStateType stateToUpdateTo = 2;
 }
+
+message GenericCommand {
+  MessageType mess_t = 1;
+  oneof kind {
+    SequenceCommand seq_m = 2;
+    AlterState alt_m = 3;
+  }
+} 
 
 message CommandReply {
   MessageType mess_t = 1;

--- a/tests/TestPriorityQueue.py
+++ b/tests/TestPriorityQueue.py
@@ -1,0 +1,28 @@
+from beams.sequencer.helpers.PriorityQueue import PriorityQueue
+from enum import IntEnum
+
+
+class Color(IntEnum):
+  RED = 0
+  YELLOW = 1
+  GREEN = 2
+
+
+class TestTask():
+  def test_1(self):
+    priority_dict = {
+      Color.RED : 0,
+      Color.YELLOW : 1,
+      Color.GREEN : 2
+    }
+    p = PriorityQueue(priority_dict)
+
+    p.put("egg", Color.YELLOW)
+    p.put("josh", Color.GREEN)
+    p.put("hyuh", Color.RED)
+    p.put("will", Color.YELLOW)
+
+    assert p.pop() == "hyuh"
+    assert p.pop() == "egg"
+    assert p.pop() == "will"
+    assert p.pop() == "josh"

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -1,0 +1,33 @@
+from beams.sequencer.helpers.Worker import Worker
+from multiprocessing import Value
+
+
+class TestTask:
+  def test_obj_instantiation(self):
+    class WorkChild(Worker):
+      def __init__(self):
+        super().__init__("test_worker")
+        self.value = Value('d', 0)
+
+      def work_func(self):
+        while (self.do_work.value or self.value.value < 100):
+          self.value.value += 10
+
+    w = WorkChild()
+    w.start_work()
+    w.stop_work()  # blocking calls join
+
+    assert w.value.value == 100
+
+  def test_class_member_instantiation(self):
+    a = Worker("test_worker")
+    val = Value('i', 10)
+    
+    def work_func(self):
+      while (self.do_work.value or val.value < 100):
+        val.value += 10
+    a.set_work_func(work_func)
+
+    a.start_work()
+    a.stop_work()
+    assert val.value == 100

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -31,3 +31,14 @@ class TestTask:
     a.start_work()
     a.stop_work()
     assert val.value == 100
+
+  def test_inline_instantation(self):
+    val = Value('i', 10)
+
+    def work_func(self):
+      while (self.do_work.value or val.value < 100):
+        val.value += 10
+    a = Worker("test_worker", work_func=work_func)
+    a.start_work()
+    a.stop_work()
+    assert val.value == 100


### PR DESCRIPTION
Still building out bones for this thing. Goal of this PR is to allow for requests to be plumbed all the way to generated trees. This gets us all the way up to but not including tree generation.

Added test coverage for the `Worker` object as well as new `PriorityQueue` object.

Updated `Sequencer` main object to launch threads required for runtime specifically:
* message handler thread: parses requests into the tree structure that will actually be ticked
* sequence server thread: GRPC process that accepts reqests
* main thread: thing that will tick jobs

I added a PriorityQueue object to `helpers` as this is the standard way to ensure you sequencer chooses the correct task to begin execution on . In the future we will need to make sure that when it receives a higher priority task than the one currently executing it pauses current execution to field the more critical task. This is enabled in the current architecture. 