### PR TITLE
REF: make CheckAndDo of base class py_trees.composites.Selector

### DIFF
--- a/beams/behavior_tree/CheckAndDo.py
+++ b/beams/behavior_tree/CheckAndDo.py
@@ -3,13 +3,10 @@ from beams.behavior_tree.ActionNode import ActionNode
 from beams.behavior_tree.ConditionNode import ConditionNode
 
 
-class CheckAndDo():
+class CheckAndDo(py_trees.composites.Selector):
   def __init__(self, name: str,  check: ConditionNode, do: ActionNode) -> None:
+    super().__init__(name, memory=True)
     self.name = name
-    self.root = py_trees.composites.Selector(self.name, memory=True)
     self.check = check
     self.do = do
-    self.root.add_children([check, do])
-
-  def setup(self):
-    self.root.setup_with_descendants()
+    self.add_children([check, do])

--- a/beams/tests/test_check_and_do.py
+++ b/beams/tests/test_check_and_do.py
@@ -29,10 +29,10 @@ class TestTask:
     check = ConditionNode.ConditionNode("check", checky, percentage_complete)
 
     candd = CheckAndDo.CheckAndDo("yuhh", check, action)
-    candd.setup()
+    candd.setup_with_descendants()
 
     for i in range(1, 10):
       time.sleep(.01)
-      candd.root.tick_once()
+      candd.tick_once()
 
     assert percentage_complete.value == 100

--- a/beams/tests/test_tree_generator.py
+++ b/beams/tests/test_tree_generator.py
@@ -39,12 +39,12 @@ def test_tree_obj_execution(request):
     )
 
     tree = tg.get_tree_from_config()
-
+    tree.setup_with_descendants()
     while (
-        tree.root.status != py_trees.common.Status.SUCCESS
-        and tree.root.status != py_trees.common.Status.FAILURE
+        tree.status != py_trees.common.Status.SUCCESS
+        and tree.status != py_trees.common.Status.FAILURE
     ):
-        for n in tree.root.tick():
+        for n in tree.tick():
             print(f"ticking: {n}")
             time.sleep(0.1)
             print(f"status of tick: {n.status}")

--- a/beams/tree_generator/TreeSerializer.py
+++ b/beams/tree_generator/TreeSerializer.py
@@ -132,7 +132,7 @@ class TreeSpec():
   children: Optional[List[CheckAndDoNodeEntry]] = None
 
   def get_tree(self):
-    children_trees = [x.get_tree().root for x in self.children]
+    children_trees = [x.get_tree() for x in self.children]
     print(children_trees)
     self.root = py_trees.composites.Sequence(self.name, memory=True)
     self.root.add_children(children_trees)

--- a/docs/source/upcoming_release_notes/20-rebase_the_CheckAndDo_class_such_that_it_extends_base_class_py_trees.composites.Selector_this_can_be_seen_as_the_first_of_beams.idioms.rst
+++ b/docs/source/upcoming_release_notes/20-rebase_the_CheckAndDo_class_such_that_it_extends_base_class_py_trees.composites.Selector_this_can_be_seen_as_the_first_of_beams.idioms.rst
@@ -1,0 +1,23 @@
+20 - joshc-slac/check-and-do-rebase-to-selector
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Becomes easier to nest check and do nodes. 
+- rebase the CheckAndDo class such that it extends base class py_trees.composites.Selector this can be seen as the first of beams.idioms
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- joshc-slac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As suggested in https://github.com/pcdshub/BEAMS/issues/20 we should rebase the `CheckAndDo` class such that it extends base class `py_trees.composites.Selector` this can be seen as the first of `beams.idioms`


<!--- Describe your changes in detail -->
**Critical Note**: It is now on the 'user' to call `setup_with_descendants()` before ticking these nodes


## Motivation and Context
This will make it much easier to chain together trees (nested, recursive trees).

**Note**:
This does not address the really unfortunate de-serialization architecture of  this being the  definition of the in memory class (called TreeSpec): https://github.com/pcdshub/BEAMS/blob/717525d747594a9a1675304edd298f6044441122/beams/tree_generator/TreeSerializer.py#L129-L143 that holds a "nested" or multi `CheckAndDo` that itself is currently retrieved with https://github.com/pcdshub/BEAMS/blob/717525d747594a9a1675304edd298f6044441122/beams/tree_generator/TreeGenerator.py#L11-L18

Though this work will make making better decisions easier as discussed in https://github.com/pcdshub/BEAMS/issues/18

## How Has This Been Tested?
Covered in unit tests

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
