### PR TITLE
FIX: race condition in test worker made it conditional on hardware speed

### DIFF
--- a/beams/tests/test_check_and_do.py
+++ b/beams/tests/test_check_and_do.py
@@ -31,8 +31,11 @@ class TestTask:
     candd = CheckAndDo.CheckAndDo("yuhh", check, action)
     candd.setup_with_descendants()
 
-    for i in range(1, 10):
-      time.sleep(.01)
-      candd.tick_once()
+    while (
+        candd.status != py_trees.common.Status.SUCCESS
+        and candd.status != py_trees.common.Status.FAILURE
+    ):
+      for i in candd.tick():
+        time.sleep(.01)
 
     assert percentage_complete.value == 100

--- a/beams/tests/test_tree_generator.py
+++ b/beams/tests/test_tree_generator.py
@@ -46,7 +46,7 @@ def test_tree_obj_execution(request):
     ):
         for n in tree.tick():
             print(f"ticking: {n}")
-            time.sleep(0.1)
+            time.sleep(0.05)
             print(f"status of tick: {n.status}")
 
     rel_val = caget("PERC:COMP")
@@ -74,7 +74,7 @@ def test_father_tree_execution(request):
         print((tree.root.status, tree.root.status, ct))
         for n in tree.root.tick():
             print(f"ticking: {n}")
-            time.sleep(0.1)
+            time.sleep(0.05)
             print(f"status of tick: {n.status}")
 
     check_insert = caget("RET:INSERT")

--- a/beams/tests/test_worker.py
+++ b/beams/tests/test_worker.py
@@ -1,3 +1,4 @@
+import time
 from multiprocessing import Value
 
 from beams.sequencer.helpers.Worker import Worker
@@ -8,11 +9,12 @@ class TestTask:
     class WorkChild(Worker):
       def __init__(self):
         super().__init__("test_worker")
-        self.value = Value('d', 0)
+        self.value = Value('d', 0)  # Note: here value is a member object 
 
       def work_func(self):
         while (self.do_work.value or self.value.value < 100):
-          self.value.value += 10
+          if (self.value.value < 100):  # Note: here we reference member object
+            self.value.value += 10
 
     w = WorkChild()
     w.start_work()
@@ -22,14 +24,16 @@ class TestTask:
 
   def test_class_member_instantiation(self):
     a = Worker("test_worker")
-    val = Value('i', 10)
+    val = Value('i', 10)  # Note: value declared here to be captured via closure
 
     def work_func(self):
       while (self.do_work.value or val.value < 100):
-        val.value += 10
+        if (val.value < 100):  # Note: value captured via closure 
+          val.value += 10  # Note: value captured via closure 
     a.set_work_func(work_func)
 
     a.start_work()
+    time.sleep(1)
     a.stop_work()
     assert val.value == 100
 
@@ -38,7 +42,8 @@ class TestTask:
 
     def work_func(self):
       while (self.do_work.value or val.value < 100):
-        val.value += 10
+        if (val.value < 100):  # Note: value captured via closure 
+          val.value += 10
     a = Worker("test_worker", work_func=work_func)
     a.start_work()
     a.stop_work()

--- a/docs/source/upcoming_release_notes/29-fix-test-worker.rst
+++ b/docs/source/upcoming_release_notes/29-fix-test-worker.rst
@@ -1,0 +1,23 @@
+29 fix-test-worker
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- test_worker was failing non deterministically due to logically ungated work functions 
+- test_check_and_do was failing non deterministically due to lack of closed loop ticking
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- joshc-slac


### PR DESCRIPTION
Closes #27 
## Description
There was a fun bug in our Worker class tests that made success conditional (or downright non deterministic) on hardware it was run on. Centered around this condition:

https://github.com/pcdshub/BEAMS/blob/4be9dc569c857e275fe573ea19e35b926ec358a1/beams/tests/test_worker.py#L28-L29

This was intended to have the logic:
> Keep work thread alive until stop work signal is sent *and* the logical task is completed

The issue being with being with no sleep in the work function on sufficiently fast hardware or with a significantly long wait for whatever reason between these two lines: https://github.com/pcdshub/BEAMS/blob/4be9dc569c857e275fe573ea19e35b926ec358a1/beams/tests/test_worker.py#L32-L33

It could count up very high as seen [here](https://github.com/pcdshub/BEAMS/actions/runs/10270927493/job/28419770161?pr=26#step:14:62)

The simple solution was adding a logic gate to incrementing the checking value. 

**Note:** There are many other solutions that might be more performant; we should benchmark in python and standardize to make sure the busy waiting / no load threads are not locking out OS. I would be surprised if python doesn't handle this for us. I miss C. 

## Motivation and Context
I want to standardize how 'work' is done for a few reasons enumerated here: #28. While this shows the issue was not in fact in our Worker declaration hopefully this PR serves as a sign post to future developers and is scaffolding for however we decide to standardize work function generation. 

Additionally  we need our tests to pass deterministically. 

## How Has This Been Tested?
In our unit tests

## Where Has This Been Documented?

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
