### PR TITLE
ENH: making doing work better

### DIFF
--- a/beams/behavior_tree/ActionNode.py
+++ b/beams/behavior_tree/ActionNode.py
@@ -44,7 +44,6 @@ class ActionNode(py_trees.behaviour.Behaviour):
         )
 
         # Having this in setup means the workthread should always be running.
-        print("LAUNCHING JAWN")
         self.worker.start_work()
         atexit.register(
             self.worker.stop_work

--- a/beams/behavior_tree/ActionNode.py
+++ b/beams/behavior_tree/ActionNode.py
@@ -20,7 +20,7 @@ class ActionNode(py_trees.behaviour.Behaviour):
         work_lock=Lock(),
         **kwargs,
     ):  # TODO: can add failure condition argument...
-        super(ActionNode, self).__init__(name)
+        super().__init__(name)
         # print(type(self.status))
         self.__volatile_status__ = VolatileStatus(self.status)
         # TODO may want to instantiate these locally and then decorate the passed work function with them
@@ -84,18 +84,13 @@ class ActionNode(py_trees.behaviour.Behaviour):
 
         return new_status
 
-    # TODO: serious introspection about that we want to do here. 
-    # def terminate(self, new_status: py_trees.common.Status) -> None:
-    #     """Nothing to clean up in this example."""
-    #     print(f"TERMINATE CALLED ON {self.name}, pid: {os.getpid()}")
-    #     if self.work_proc.is_alive():
-    #         print(f"The process is still alive on {os.getpid()}")
-    #         self.work_proc.terminate()
-    #         self.logger.debug(
-    #             py_trees.console.red
-    #             + "%s.terminate()[%s->%s]"
-    #             % (self.__class__.__name__, self.status, new_status)
-    #         )
+    def terminate(self, new_status: py_trees.common.Status) -> None:
+        """Nothing to clean up."""
+        self.logger.debug(
+            py_trees.console.red
+            + "%s.terminate()[%s->%s]"
+            % (self.__class__.__name__, self.status, new_status)
+        )
 
 
 if __name__ == "__main__":

--- a/beams/behavior_tree/ActionWorker.py
+++ b/beams/behavior_tree/ActionWorker.py
@@ -21,5 +21,6 @@ class ActionWorker(Worker):
                          work_func=work_func,
                          proc_type=CAProcess,
                          add_args=(comp_cond, volatile_status))
-        self.comp_condition = comp_cond
-        self.__volatile_status__ = volatile_status
+
+    # Note: there may be a world where we define a common stop_func here in which case 
+    # the class may have maintain a reference to voltaile_status and or comp_cond

--- a/beams/behavior_tree/ActionWorker.py
+++ b/beams/behavior_tree/ActionWorker.py
@@ -1,3 +1,6 @@
+"""
+A worker specialized to execute ActionNode work functions
+"""
 from typing import Callable, Any, Optional
 
 from epics.multiproc import CAProcess
@@ -18,6 +21,5 @@ class ActionWorker(Worker):
                          work_func=work_func,
                          proc_type=CAProcess,
                          add_args=(comp_cond, volatile_status))
-        print(f"YO SELF: {self}")
         self.comp_condition = comp_cond
         self.__volatile_status__ = volatile_status

--- a/beams/behavior_tree/ActionWorker.py
+++ b/beams/behavior_tree/ActionWorker.py
@@ -1,0 +1,23 @@
+from typing import Callable, Any, Optional
+
+from epics.multiproc import CAProcess
+
+from beams.sequencer.helpers.Worker import Worker
+from beams.behavior_tree.VolatileStatus import VolatileStatus
+
+
+class ActionWorker(Worker):
+    def __init__(self,
+                 proc_name: str, 
+                 volatile_status: VolatileStatus,
+                 work_func: Callable[[Any], None],
+                 comp_cond: Callable[[Any], bool],
+                 stop_func: Optional[Callable[[None], None]] = None):
+        super().__init__(proc_name=proc_name,
+                         stop_func=stop_func,
+                         work_func=work_func,
+                         proc_type=CAProcess,
+                         add_args=(comp_cond, volatile_status))
+        print(f"YO SELF: {self}")
+        self.comp_condition = comp_cond
+        self.__volatile_status__ = volatile_status

--- a/beams/behavior_tree/CheckAndDo.py
+++ b/beams/behavior_tree/CheckAndDo.py
@@ -6,7 +6,7 @@ from beams.behavior_tree.ConditionNode import ConditionNode
 
 class CheckAndDo(py_trees.composites.Selector):
     def __init__(self, name: str, check: ConditionNode, do: ActionNode) -> None:
-        super().__init__(name, memory=True)
+        super().__init__(name, memory=False)
         self.name = name
         self.check = check
         self.do = do

--- a/beams/sequencer/helpers/Worker.py
+++ b/beams/sequencer/helpers/Worker.py
@@ -48,8 +48,8 @@ class Worker():
         self.do_work.value = False
         logging.info(f"Sending terminate signal to{self.work_proc.pid}")
         # Send kill signal to work process. # TODO: the exact loc ation of this is important. Reflect
-        with self.do_work.get_lock():
-            self.work_proc.terminate()
+        # with self.do_work.get_lock():
+        self.work_proc.terminate()
         if (self.stop_func is not None):
             self.stop_func()
 

--- a/beams/sequencer/helpers/Worker.py
+++ b/beams/sequencer/helpers/Worker.py
@@ -35,16 +35,20 @@ class Worker():
             logging.error("Already working, not starting work")
             return
         self.do_work.value = True
+        print(self.work_func)
         self.work_proc.start()
         logging.debug(f"Starting work on: {self.work_proc.pid}")
 
     def stop_work(self):
         logging.info(f"Calling stop work on: {self.work_proc.pid}")
-        if not self.do_work.value:
+        if (not self.do_work.value):
             logging.error("Not working, not stopping work")
             return
         self.do_work.value = False
-        if self.stop_func is not None:
+        logging.info(f"Sending terminate signal to{self.work_proc.pid}")
+        # Send kill signal to work process. # TODO: the exact location of this is important. Reflect
+        self.work_proc.terminate()
+        if (self.stop_func is not None):
             self.stop_func()
 
         logging.info("calling join")

--- a/beams/sequencer/helpers/Worker.py
+++ b/beams/sequencer/helpers/Worker.py
@@ -6,9 +6,7 @@
 """
 import logging
 from multiprocessing import Process, Value
-from typing import Callable, Any, Optional, Union, List
-
-from epics.multiproc import CAProcess
+from typing import Callable, Any, Optional, List
 
 
 class Worker():
@@ -16,7 +14,7 @@ class Worker():
                  proc_name: str, 
                  stop_func: Optional[Callable[[None], None]] = None, 
                  work_func: Optional[Callable[[Any], None]] = None,
-                 proc_type: Union[Process, CAProcess] = Process,
+                 proc_type: type[Process] = Process,
                  add_args: List[Any] = []
                  ):
         self.do_work = Value('i', False)
@@ -31,18 +29,16 @@ class Worker():
         self.stop_func = stop_func
 
     def start_work(self):
-        if (self.do_work.value):
+        if self.do_work.value:
             logging.error("Already working, not starting work")
             return
         self.do_work.value = True
-        print(self.work_func)
-        # breakpoint()
         self.work_proc.start()
         logging.debug(f"Starting work on: {self.work_proc.pid}")
 
     def stop_work(self):
         logging.info(f"Calling stop work on: {self.work_proc.pid}")
-        if (not self.do_work.value):
+        if not self.do_work.value:
             logging.error("Not working, not stopping work")
             return
         self.do_work.value = False

--- a/beams/tests/artifacts/eggs.json
+++ b/beams/tests/artifacts/eggs.json
@@ -4,7 +4,7 @@
       "name": "self_test",
       "description": "",
       "check": {
-        "name": "",
+        "name": "self_test_check",
         "description": "",
         "pv": "PERC:COMP",
         "value": 100,
@@ -12,9 +12,9 @@
       },
       "do": {
         "IncPVActionItem": {
-          "name": "",
+          "name": "self_test_do",
           "description": "",
-          "loop_period_sec": 1.0,
+          "loop_period_sec": 0.01,
           "pv": "PERC:COMP",
           "increment": 10,
           "termination_check": {

--- a/beams/tests/artifacts/eggs2.json
+++ b/beams/tests/artifacts/eggs2.json
@@ -10,7 +10,7 @@
             "name": "ret_find",
             "description": "",
             "check": {
-              "name": "",
+              "name": "ret_find_check",
               "description": "",
               "pv": "RET:FOUND",
               "value": 1,
@@ -18,9 +18,9 @@
             },
             "do": {
               "SetPVActionItem": {
-                "name": "",
+                "name": "ret_find_do",
                 "description": "",
-                "loop_period_sec": 1.0,
+                "loop_period_sec": 0.01,
                 "pv": "RET:FOUND",
                 "value": 1,
                 "termination_check": {

--- a/beams/tests/test_check_and_do.py
+++ b/beams/tests/test_check_and_do.py
@@ -10,13 +10,12 @@ class TestTask:
     def test_check_and_do(self, capsys):
         percentage_complete = Value("i", 0)
 
-        def thisjob(comp_condition, volatile_status, **kwargs) -> None:
+        def thisjob(myself, comp_condition, volatile_status) -> None:
             # TODO: grabbing intended keyword argument. Josh's less than pythonic mechanism for closures
             volatile_status.set_value(py_trees.common.Status.RUNNING)
-            percentage_complete = kwargs["percentage_complete"]
             while not comp_condition(percentage_complete.value):
                 py_trees.console.logdebug(
-                    f"yuh {percentage_complete.value}, {volatile_status.get_value()}"
+                    f"PERC COMP {percentage_complete.value}, {volatile_status.get_value()}"
                 )
                 percentage_complete.value += 10
                 if percentage_complete.value == 100:
@@ -26,7 +25,9 @@ class TestTask:
         py_trees.logging.level = py_trees.logging.Level.DEBUG
         comp_cond = lambda x: x == 100
         action = ActionNode.ActionNode(
-            "action", thisjob, comp_cond, percentage_complete=percentage_complete
+            name="action", 
+            work_func=thisjob, 
+            completion_condition=comp_cond
         )
 
         checky = lambda x: x.value == 100

--- a/beams/tests/test_leaf_node.py
+++ b/beams/tests/test_leaf_node.py
@@ -13,31 +13,24 @@ class TestTask:
         # For test
         percentage_complete = Value("i", 0)
 
-        def thisjob(comp_condition, volatile_status, **kwargs) -> None:
-            try:
-                # grabbing intended keyword argument. Josh's less than pythonic mechanism for closures
-                volatile_status.set_value(py_trees.common.Status.RUNNING)
-                percentage_complete = kwargs["percentage_complete"]
-                while not comp_condition(percentage_complete.value):
-                    py_trees.console.logdebug(
-                        f"yuh {percentage_complete.value}, {volatile_status.get_value()}"
-                    )
-                    percentage_complete.value += 10
-                    if percentage_complete.value == 100:
-                        volatile_status.set_value(py_trees.common.Status.SUCCESS)
-                    time.sleep(0.001)
-            except KeyboardInterrupt:
-                pass
+        def thisjob(myself, comp_condition, volatile_status) -> None:
+            volatile_status.set_value(py_trees.common.Status.RUNNING)
+            while not comp_condition(percentage_complete.value):
+                py_trees.console.logdebug(f"yuh {percentage_complete.value}, {volatile_status.get_value()}")
+                percentage_complete.value += 10
+                if percentage_complete.value == 100:
+                  volatile_status.set_value(py_trees.common.Status.SUCCESS)
+                time.sleep(0.001)
 
         py_trees.logging.level = py_trees.logging.Level.DEBUG
         comp_cond = lambda x: x == 100
-        action = ActionNode(
-            "action", thisjob, comp_cond, percentage_complete=percentage_complete
-        )
+        action = ActionNode(name="action", 
+                            work_func=thisjob, 
+                            completion_condition=comp_cond)
         action.setup()
         for i in range(20):
-            time.sleep(0.01)
-            action.tick_once()
+          time.sleep(0.01)
+          action.tick_once()
 
         assert percentage_complete.value == 100
 

--- a/beams/tests/test_sequencer_state.py
+++ b/beams/tests/test_sequencer_state.py
@@ -28,24 +28,3 @@ class TestTask:
         assert y[SequencerStateVariable.STATUS.value] == TickStatus.UNKNOWN
         assert y[SequencerStateVariable.RUN_STATE.value] == RunStateType.STATE_UNKNOWN
         assert y["mess_t"] == MessageType.MESSAGE_TYPE_COMMAND_REPLY
-
-    def test_multi_access(self):
-        x = SequencerState()
-
-        def proc1work(x):
-            print("proc1 a go")
-            x.set_value(SequencerStateVariable.RUN_STATE, RunStateType.TICKING)
-
-        def proc2work(x):
-            print("proc2 a go")
-            while x.get_value(SequencerStateVariable.RUN_STATE) != RunStateType.TICKING:
-                print("waiting for get value to return true")
-                time.sleep(0.1)
-
-            assert x.get_value(SequencerStateVariable.RUN_STATE) == RunStateType.TICKING
-
-        proc1 = Process(target=proc1work, args=(x,))
-        proc2 = Process(target=proc2work, args=(x,))
-        proc2.start()
-        time.sleep(0.4)
-        proc1.start()

--- a/beams/tests/test_tree_generator.py
+++ b/beams/tests/test_tree_generator.py
@@ -33,8 +33,9 @@ def test_tree_obj_execution(request):
         py_trees.common.Status.SUCCESS,
         py_trees.common.Status.FAILURE,
     ):
-        tree.tick()
-        time.sleep(0.05)
+        for n in tree.root.tick():
+            print(n)
+            time.sleep(0.05)
 
     rel_val = caget("PERC:COMP")
     assert rel_val >= 100
@@ -56,10 +57,11 @@ def test_father_tree_execution(request):
         not in (py_trees.common.Status.SUCCESS, py_trees.common.Status.FAILURE)
         and ct < 50
     ):
-        ct += 1
-        print((tree.root.status, tree.root.status, ct))
-        tree.tick()
-        time.sleep(0.05)
+        for n in tree.root.tick():
+            ct += 1
+            print(n)
+            print((tree.root.status, tree.root.status, ct))
+            time.sleep(0.05)
 
     check_insert = caget("RET:INSERT")
 

--- a/beams/tests/test_worker.py
+++ b/beams/tests/test_worker.py
@@ -1,26 +1,33 @@
 import time
 from multiprocessing import Value
-
 from beams.sequencer.helpers.Worker import Worker
 
 
 class TestTask:
     def test_obj_instantiation(self):
-        class WorkChild(Worker):
-            def __init__(self):
-                super().__init__("test_worker")
-                self.value = Value("d", 0)  # Note: here value is a member object
+        class CoolWorker(Worker):
+            def __init__(self,
+                         proc_name: str,
+                         work_func):
+                super().__init__(proc_name=proc_name,
+                                 work_func=work_func,
+                                 add_args=())
+                self.val = Value('i', 0)
 
-            def work_func(self):
-                while self.do_work.value or self.value.value < 100:
-                    if self.value.value < 100:  # Note: here we reference member object
-                        self.value.value += 10
+        def work_func(self):
+            while self.do_work.value or self.val.value < 100:
+                if self.val.value < 100:  # Note: value captured via closure
+                    time.sleep(0.01)
+                    with self.val.get_lock():
+                        self.val.value += 10  # Note: value captured via closure
 
-        w = WorkChild()
-        w.start_work()
-        w.stop_work()  # blocking calls join
-
-        assert w.value.value == 100
+        c = CoolWorker("cool_guy",
+                       work_func=work_func)
+        c.start_work()
+        time.sleep(1)  # Note: need actual time for the thing to happen
+        c.stop_work()
+        with c.val.get_lock():
+            assert c.val.value == 100
 
     def test_class_member_instantiation(self):
         a = Worker("test_worker")
@@ -43,10 +50,13 @@ class TestTask:
 
         def work_func(self):
             while self.do_work.value or val.value < 100:
-                if val.value < 100:  # Note: value captured via closure
-                    val.value += 10
+                time.sleep(0.01)
+                with val.get_lock():
+                    if val.value < 100:  # Note: value captured via closure
+                        val.value += 10
 
         a = Worker("test_worker", work_func=work_func)
         a.start_work()
+        time.sleep(1)
         a.stop_work()
         assert val.value == 100

--- a/beams/tests/test_worker.py
+++ b/beams/tests/test_worker.py
@@ -17,6 +17,9 @@ class TestTask:
         def work_func(self):
             while self.do_work.value or self.val.value < 100:
                 if self.val.value < 100:  # Note: value captured via closure
+                    # Note: even in python if a full bore loop captures a lock other Processes may not have time 
+                    # to acquire this shared resource; therefore the sleep is very strongly suggested if not needed
+                    # when using a lock
                     time.sleep(0.01)
                     with self.val.get_lock():
                         self.val.value += 10  # Note: value captured via closure

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -171,20 +171,9 @@ class SetPVActionItem(ActionItem):
         wait_for_tick = Event()
         wait_for_tick_lock = Lock()
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        def work_func(comp_condition, volatile_status):
-            py_trees.console.logdebug(
-                f"WAITING FOR INIT {os.getpid()} " f"from node: {self.name}"
-            )
-=======
-        def work_func(self):
-=======
         def work_func(myself, comp_condition, volatile_status):
->>>>>>> b289496 (ENH: Successfully replumbed action node work to be facilliated by base)
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
->>>>>>> 6d6518b (ENH: making doing work better)
             wait_for_tick.wait()
 
             # Set to running
@@ -239,16 +228,9 @@ class IncPVActionItem(ActionItem):
         wait_for_tick = Event()
         wait_for_tick_lock = Lock()
 
-<<<<<<< HEAD
-        def work_func(comp_condition, volatile_status):
-            py_trees.console.logdebug(
-                f"WAITING FOR INIT {os.getpid()} " f"from node: {self.name}"
-            )
-=======
         def work_func(myself, comp_condition, volatile_status):
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
->>>>>>> b289496 (ENH: Successfully replumbed action node work to be facilliated by base)
             wait_for_tick.wait()
 
             # Set to running

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -167,30 +167,37 @@ class SetPVActionItem(ActionItem):
     termination_check: ConditionItem = field(default_factory=ConditionItem)
 
     def get_tree(self) -> ActionNode:
+        # TODO: can I put these two lines in a decorator which action node uses on the function?
         wait_for_tick = Event()
         wait_for_tick_lock = Lock()
 
+<<<<<<< HEAD
         def work_func(comp_condition, volatile_status):
             py_trees.console.logdebug(
                 f"WAITING FOR INIT {os.getpid()} " f"from node: {self.name}"
             )
+=======
+        def work_func(self):
+            py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
+                                      f"from node: {self.name}")
+>>>>>>> 6d6518b (ENH: making doing work better)
             wait_for_tick.wait()
 
             # Set to running
             value = 0
 
             # While termination_check is not True
-            while not comp_condition():  # TODO check work_gate.is_set()
+            while not self.comp_condition():  # TODO check work_gate.is_set()
                 py_trees.console.logdebug(
                     f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
                 )
                 value = caget(self.termination_check.pv)
 
-                if comp_condition():
-                    volatile_status.set_value(py_trees.common.Status.SUCCESS)
+                if self.comp_condition():
+                    self.volatile_status.set_value(py_trees.common.Status.SUCCESS)
                 py_trees.console.logdebug(
                     f"{self.name}: Value is {value}, BT Status: "
-                    f"{volatile_status.get_value()}"
+                    f"{self.volatile_status.get_value()}"
                 )
 
                 # specific caput logic to SetPVActionItem
@@ -198,10 +205,10 @@ class SetPVActionItem(ActionItem):
                 time.sleep(self.loop_period_sec)
 
             # one last check
-            if comp_condition():
-                volatile_status.set_value(py_trees.common.Status.SUCCESS)
+            if self.comp_condition():
+                self.volatile_status.set_value(py_trees.common.Status.SUCCESS)
             else:
-                volatile_status.set_value(py_trees.common.Status.FAILURE)
+                self.volatile_status.set_value(py_trees.common.Status.FAILURE)
 
         comp_cond = self.termination_check.get_condition_function()
 

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -172,12 +172,16 @@ class SetPVActionItem(ActionItem):
         wait_for_tick_lock = Lock()
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         def work_func(comp_condition, volatile_status):
             py_trees.console.logdebug(
                 f"WAITING FOR INIT {os.getpid()} " f"from node: {self.name}"
             )
 =======
         def work_func(self):
+=======
+        def work_func(myself, comp_condition, volatile_status):
+>>>>>>> b289496 (ENH: Successfully replumbed action node work to be facilliated by base)
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
 >>>>>>> 6d6518b (ENH: making doing work better)
@@ -187,17 +191,17 @@ class SetPVActionItem(ActionItem):
             value = 0
 
             # While termination_check is not True
-            while not self.comp_condition():  # TODO check work_gate.is_set()
+            while not comp_condition():  # TODO check work_gate.is_set()
                 py_trees.console.logdebug(
                     f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
                 )
                 value = caget(self.termination_check.pv)
 
-                if self.comp_condition():
-                    self.volatile_status.set_value(py_trees.common.Status.SUCCESS)
+                if comp_condition():
+                    volatile_status.set_value(py_trees.common.Status.SUCCESS)
                 py_trees.console.logdebug(
                     f"{self.name}: Value is {value}, BT Status: "
-                    f"{self.volatile_status.get_value()}"
+                    f"{volatile_status.get_value()}"
                 )
 
                 # specific caput logic to SetPVActionItem
@@ -205,10 +209,10 @@ class SetPVActionItem(ActionItem):
                 time.sleep(self.loop_period_sec)
 
             # one last check
-            if self.comp_condition():
-                self.volatile_status.set_value(py_trees.common.Status.SUCCESS)
+            if comp_condition():
+                volatile_status.set_value(py_trees.common.Status.SUCCESS)
             else:
-                self.volatile_status.set_value(py_trees.common.Status.FAILURE)
+                volatile_status.set_value(py_trees.common.Status.FAILURE)
 
         comp_cond = self.termination_check.get_condition_function()
 
@@ -235,10 +239,16 @@ class IncPVActionItem(ActionItem):
         wait_for_tick = Event()
         wait_for_tick_lock = Lock()
 
+<<<<<<< HEAD
         def work_func(comp_condition, volatile_status):
             py_trees.console.logdebug(
                 f"WAITING FOR INIT {os.getpid()} " f"from node: {self.name}"
             )
+=======
+        def work_func(myself, comp_condition, volatile_status):
+            py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
+                                      f"from node: {self.name}")
+>>>>>>> b289496 (ENH: Successfully replumbed action node work to be facilliated by base)
             wait_for_tick.wait()
 
             # Set to running


### PR DESCRIPTION
The base `Worker` class was previously implemented to wrap `multiprocessing.Process` such that we could standardize process spawning and management mechanisms and propagate those changes efficiently through the codebase. 

With this in mind it made sense for our ActionNodes which inherently utilize Process's to build off of this functionality. 

## Description
We made a subclass of `Worker` called `ActionNodeWorker` which extends the Worker base class to hold the necessary interprocess communication elements needed by any ActionNode in relation to its spawned processes namely:
* __voltaile_status__ : a `multiprocessing.Value` which wraps an enum to communcate BT status up to parent node
* completion_condition: the `Callable[[None], bool]`[^1] which determines work function completion


[^1]: for full transparency this is captured by closure in the `ConditionItem` class which is partly why its valuable to pass an argument to the spawned process by the CAProcess command

This has a two fold effect:
* Ownership of IPC variables is concretized logically to the ActionNode class
* IPC nitty gritty is abstracted from the user space of defining the work function and completion condition. Currently in tree_config.py

## Motivation and Context
* With the goal of having more than "one shot" trees we need a mechanism to make a while loop that lasts the lifecycle of the program but still terminates the Worker class gives us a mechanism to do so, we may as well use it
* It is critical we standardized how work is spawned and managed lest we end up doing it differently all over the codebase which would make debugging and feature addition difficult.  


## How Has This Been Tested?
Unit tests (run better now even)

## Where Has This Been Documented?
[Slides](https://docs.google.com/presentation/d/1nmNLD5k6Zr7mg9HHmRI7F9PInfzq3mMka_9P8WJ_94E/edit?usp=sharing)

![image](https://github.com/user-attachments/assets/e1f4ad44-b9d0-4c46-905d-4b5c162269da)
 

## Todo: 
In a PR based of this one we will take advantage of the "more than one shot" trees which will take full advantage of the reactivity of BTs. Two things are needed:
* make current tests more than one shot capable
* write tests that will only pass **if** they work in a more than one shot fashion. i.e. unset a PV after its been set

I am leaving these as future TODOs to keep this PR readable and make pace of dev apparent. 

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
