### PR TITLE
Utilizing "multi shot" ability of trees

### DIFF
--- a/beams/behavior_tree/ActionWorker.py
+++ b/beams/behavior_tree/ActionWorker.py
@@ -1,6 +1,7 @@
 """
 A worker specialized to execute ActionNode work functions
 """
+from multiprocessing import Event
 from typing import Callable, Any, Optional
 
 from epics.multiproc import CAProcess
@@ -14,13 +15,18 @@ class ActionWorker(Worker):
                  proc_name: str, 
                  volatile_status: VolatileStatus,
                  work_func: Callable[[Any], None],
+                 wait_for_tick: Event,
                  comp_cond: Callable[[Any], bool],
                  stop_func: Optional[Callable[[None], None]] = None):
         super().__init__(proc_name=proc_name,
                          stop_func=stop_func,
                          work_func=work_func,
                          proc_type=CAProcess,
-                         add_args=(comp_cond, volatile_status))
+                         add_args=(comp_cond, volatile_status, wait_for_tick))
 
     # Note: there may be a world where we define a common stop_func here in which case 
     # the class may have maintain a reference to voltaile_status and or comp_cond
+
+    # Note: the function passed to action_worker needs to have 4 arguments of 
+    # (self, comp_condition, volatile_status, event). I am considering using functools.wraps and inspect.signature
+    # to ensure that the work function is well formatted...

--- a/beams/tests/test_check_and_do.py
+++ b/beams/tests/test_check_and_do.py
@@ -1,16 +1,20 @@
 import time
+from typing import Callable, Any
 from multiprocessing import Value
 
 import py_trees
 
-from beams.behavior_tree import ActionNode, CheckAndDo, ConditionNode
+from beams.behavior_tree import ActionNode, CheckAndDo, ConditionNode, VolatileStatus
 
 
 class TestTask:
     def test_check_and_do(self, capsys):
         percentage_complete = Value("i", 0)
 
-        def thisjob(myself, comp_condition, volatile_status) -> None:
+        def thisjob(myself, 
+                    comp_condition: Callable[[Any], None], 
+                    volatile_status: VolatileStatus,
+                    *args) -> None:
             # TODO: grabbing intended keyword argument. Josh's less than pythonic mechanism for closures
             volatile_status.set_value(py_trees.common.Status.RUNNING)
             while not comp_condition(percentage_complete.value):

--- a/beams/tests/test_leaf_node.py
+++ b/beams/tests/test_leaf_node.py
@@ -1,10 +1,12 @@
 import time
+from typing import Callable, Any
 from multiprocessing import Value
 
 import py_trees
 
 from beams.behavior_tree.ActionNode import ActionNode
 from beams.behavior_tree.ConditionNode import ConditionNode
+from beams.behavior_tree.VolatileStatus import VolatileStatus
 
 
 class TestTask:
@@ -13,7 +15,10 @@ class TestTask:
         # For test
         percentage_complete = Value("i", 0)
 
-        def thisjob(myself, comp_condition, volatile_status) -> None:
+        def thisjob(myself, 
+                    comp_condition: Callable[[Any], None], 
+                    volatile_status: VolatileStatus, 
+                    *args) -> None:
             volatile_status.set_value(py_trees.common.Status.RUNNING)
             while not comp_condition(percentage_complete.value):
                 py_trees.console.logdebug(f"yuh {percentage_complete.value}, {volatile_status.get_value()}")

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -167,11 +167,10 @@ class SetPVActionItem(ActionItem):
     termination_check: ConditionItem = field(default_factory=ConditionItem)
 
     def get_tree(self) -> ActionNode:
-        # TODO: can I put these two lines in a decorator which action node uses on the function?
-        wait_for_tick = Event()
-        wait_for_tick_lock = Lock()
-
-        def work_func(myself, comp_condition, volatile_status):
+        def work_func(myself, 
+                      comp_condition: Callable[[Any], bool], 
+                      volatile_status: VolatileStatus, 
+                      wait_for_tick: Event()):
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
             wait_for_tick.wait()
@@ -206,8 +205,6 @@ class SetPVActionItem(ActionItem):
             name=self.name,
             work_func=work_func,
             completion_condition=comp_cond,
-            work_gate=wait_for_tick,
-            work_lock=wait_for_tick_lock,
         )
 
         return node
@@ -222,10 +219,10 @@ class IncPVActionItem(ActionItem):
 
     # TODO: DRY this out a bit
     def get_tree(self) -> ActionNode:
-        wait_for_tick = Event()
-        wait_for_tick_lock = Lock()
-
-        def work_func(myself, comp_condition, volatile_status):
+        def work_func(myself, 
+              comp_condition: Callable[[Any], bool], 
+              volatile_status: VolatileStatus, 
+              wait_for_tick: Event()):
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
             wait_for_tick.wait()
@@ -260,8 +257,6 @@ class IncPVActionItem(ActionItem):
             name=self.name,
             work_func=work_func,
             completion_condition=comp_cond,
-            work_gate=wait_for_tick,
-            work_lock=wait_for_tick_lock,
         )
 
         return node

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -171,33 +171,34 @@ class SetPVActionItem(ActionItem):
                       comp_condition: Callable[[Any], bool], 
                       volatile_status: VolatileStatus, 
                       wait_for_tick: Event()):
-            py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
-                                      f"from node: {self.name}")
-            wait_for_tick.wait()
+            while myself.do_work.value:
+                py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
+                                          f"from node: {self.name}")
+                wait_for_tick.wait()
 
-            # While termination_check is not True
-            while not comp_condition():  # TODO check work_gate.is_set()
-                py_trees.console.logdebug(
-                    f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
-                )
-                value = caget(self.termination_check.pv)
+                # While termination_check is not True
+                while not comp_condition():  # TODO check work_gate.is_set()
+                    py_trees.console.logdebug(
+                        f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
+                    )
+                    value = caget(self.termination_check.pv)
 
+                    if comp_condition():
+                        volatile_status.set_value(py_trees.common.Status.SUCCESS)
+                    py_trees.console.logdebug(
+                        f"{self.name}: Value is {value}, BT Status: "
+                        f"{volatile_status.get_value()}"
+                    )
+
+                    # specific caput logic to SetPVActionItem
+                    caput(self.pv, self.value)
+                    time.sleep(self.loop_period_sec)
+
+                # one last check
                 if comp_condition():
                     volatile_status.set_value(py_trees.common.Status.SUCCESS)
-                py_trees.console.logdebug(
-                    f"{self.name}: Value is {value}, BT Status: "
-                    f"{volatile_status.get_value()}"
-                )
-
-                # specific caput logic to SetPVActionItem
-                caput(self.pv, self.value)
-                time.sleep(self.loop_period_sec)
-
-            # one last check
-            if comp_condition():
-                volatile_status.set_value(py_trees.common.Status.SUCCESS)
-            else:
-                volatile_status.set_value(py_trees.common.Status.FAILURE)
+                else:
+                    volatile_status.set_value(py_trees.common.Status.FAILURE)
 
         comp_cond = self.termination_check.get_condition_function()
 
@@ -223,33 +224,34 @@ class IncPVActionItem(ActionItem):
               comp_condition: Callable[[Any], bool], 
               volatile_status: VolatileStatus, 
               wait_for_tick: Event()):
-            py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
-                                      f"from node: {self.name}")
-            wait_for_tick.wait()
+            while myself.do_work.value:
+                py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
+                                          f"from node: {self.name}")
+                wait_for_tick.wait()
 
-            # While termination_check is not True
-            while not comp_condition():  # TODO check work_gate.is_set()
-                py_trees.console.logdebug(
-                    f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
-                )
-                value = caget(self.pv)
+                # While termination_check is not True
+                while not comp_condition():  # TODO check work_gate.is_set()
+                    py_trees.console.logdebug(
+                        f"CALLING CAGET FROM {os.getpid()} from node: " f"{self.name}"
+                    )
+                    value = caget(self.pv)
 
+                    if comp_condition():
+                        volatile_status.set_value(py_trees.common.Status.SUCCESS)
+                    py_trees.console.logdebug(
+                        f"{self.name}: Value is {value}, BT Status: "
+                        f"{volatile_status.get_value()}"
+                    )
+
+                    # specific caput logic to IncPVActionItem
+                    caput(self.pv, value + self.increment)
+                    time.sleep(self.loop_period_sec)
+
+                # one last check
                 if comp_condition():
                     volatile_status.set_value(py_trees.common.Status.SUCCESS)
-                py_trees.console.logdebug(
-                    f"{self.name}: Value is {value}, BT Status: "
-                    f"{volatile_status.get_value()}"
-                )
-
-                # specific caput logic to IncPVActionItem
-                caput(self.pv, value + self.increment)
-                time.sleep(self.loop_period_sec)
-
-            # one last check
-            if comp_condition():
-                volatile_status.set_value(py_trees.common.Status.SUCCESS)
-            else:
-                volatile_status.set_value(py_trees.common.Status.FAILURE)
+                else:
+                    volatile_status.set_value(py_trees.common.Status.FAILURE)
 
         comp_cond = self.termination_check.get_condition_function()
 

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -176,9 +176,6 @@ class SetPVActionItem(ActionItem):
                                       f"from node: {self.name}")
             wait_for_tick.wait()
 
-            # Set to running
-            value = 0
-
             # While termination_check is not True
             while not comp_condition():  # TODO check work_gate.is_set()
                 py_trees.console.logdebug(
@@ -232,9 +229,6 @@ class IncPVActionItem(ActionItem):
             py_trees.console.logdebug(f"WAITING FOR INIT {os.getpid()} "
                                       f"from node: {self.name}")
             wait_for_tick.wait()
-
-            # Set to running
-            value = 0
 
             # While termination_check is not True
             while not comp_condition():  # TODO check work_gate.is_set()


### PR DESCRIPTION
## Description
* Slight maintenance to tend our garden and guard against Maxwell's demon.  
* Two line feature add in tree_config.py to allow for multi shot! Thanks to #34 
* Tests to show that trees are now reactive!!
* Closes #36 


## Motivation and Context
Half the whole point of sequence automation is to actively manage the state of our configured devices such that should they transition to an undesired state they can automatically transition back along defined transition vectors. Up until this point all the work packaged in ActionNodes only ran once, this will keep it living with the life cycle of the program such that when the tree is traversed again and a CheckAndDo node notices a state is out of whack it can fire off the action to deal with it again!


## Details
### FEAT:
Not multi shot:
https://github.com/pcdshub/BEAMS/blob/a2c883fc6669a89e44e5ab3908b34abdc114a0e6/beams/tree_config.py#L169-L179
Multi shot!:
https://github.com/pcdshub/BEAMS/blob/fb2f291579fb92d683e9247bc11a6c547bd4076e/beams/tree_config.py#L169-L180

this works because atexit registers the Worker classes stop_work function during the setup call of the ActionNode: 
https://github.com/pcdshub/BEAMS/blob/fb2f291579fb92d683e9247bc11a6c547bd4076e/beams/behavior_tree/ActionNode.py#L45-L49
### MNT:
Taking advantage of PR #34 which concertized all work this library packages in the Worker class, for ActionNodes augmented by the derived class ActionWorker. 

This PR does a little maintenance nitty gritty of cleaning up moving the inter-proccess communication variables to being owned by the ActionNode class as opposed to being defined in the work function which I am considering "super user space". 

Before:
https://github.com/pcdshub/BEAMS/blob/a50c0dd083d17476c440753e3bf372766c18f142/beams/behavior_tree/ActionNode.py#L27-L34

Now:
https://github.com/pcdshub/BEAMS/blob/98a646d3353beb8b9fd3897440afa9261ff8d4b3/beams/behavior_tree/ActionNode.py#L23-L33

This requires that we slightly change the signature of our work functions such that they can take this Event() object defined in the ActionNode class[^1] and that ActionWorker pass the Event as an additional argument to the add_arg field of Worker. Convenient that we decided to wrap Worker this way... extensible.. josh pats himself on the back. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->


[^1]:I really want to take advantage of wrappers / functools / inspect to very nicely package the work that gets serialized / specified in tree_config. Have said before but 80% of user needs should be met with jsonic config files. I would like the remaining 20% to be able to very easily / neatly write their own functions I think thats a 10x increase in the capability of this library. I still want to obfuscate IPC concerns from those 20%, I feel like checking that ActionWorker work funcs are correctly defined (signature-ed minimally). I think #35 is also very related.  

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
