### PR TITLE
ENH: Add cli framework

### DIFF
--- a/beams/__init__.py
+++ b/beams/__init__.py
@@ -1,0 +1,3 @@
+from .version import __version__  # noqa: F401
+
+__all__ = []

--- a/beams/__main__.py
+++ b/beams/__main__.py
@@ -1,0 +1,3 @@
+from .bin.main import main
+
+main()

--- a/beams/bin/__init__.py
+++ b/beams/bin/__init__.py
@@ -1,0 +1,3 @@
+from . import main
+
+__all__ = ["main"]

--- a/beams/bin/main.py
+++ b/beams/bin/main.py
@@ -1,0 +1,96 @@
+"""
+`beams` is the top-level command for accessing various subcommands.
+"""
+
+import argparse
+import importlib
+import logging
+
+import beams
+from beams.logging import setup_logging
+
+DESCRIPTION = __doc__
+
+
+COMMAND_TO_MODULE = {
+    "run": "run",
+}
+
+
+def _try_import(module_name):
+    return importlib.import_module(f".{module_name}", "beams.bin")
+
+
+def _build_commands():
+    global DESCRIPTION
+    result = {}
+    unavailable = []
+
+    for command, module_name in sorted(COMMAND_TO_MODULE.items()):
+        try:
+            module = _try_import(module_name)
+        except Exception as ex:
+            unavailable.append((command, ex))
+        else:
+            result[module_name] = (module.build_arg_parser, module.main)
+            DESCRIPTION += f'\n    $ beams {command} --help'
+
+    if unavailable:
+        DESCRIPTION += '\n\n'
+
+        for command, ex in unavailable:
+            DESCRIPTION += (
+                f'\nWARNING: "beams {command}" is unavailable due to:'
+                f'\n\t{ex.__class__.__name__}: {ex}'
+            )
+
+    return result
+
+
+COMMANDS = _build_commands()
+
+
+def main():
+    top_parser = argparse.ArgumentParser(
+        prog='beams',
+        description=DESCRIPTION,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    top_parser.add_argument(
+        '--version', '-V',
+        action='version',
+        version=beams.__version__,
+        help="Show the beams version number and exit."
+    )
+
+    top_parser.add_argument(
+        '--log', '-l', dest='log_level',
+        default='INFO',
+        type=str,
+        help='Python logging level (e.g. DEBUG, INFO, WARNING)'
+    )
+
+    subparsers = top_parser.add_subparsers(help='Possible subcommands')
+    for command_name, (build_func, main) in COMMANDS.items():
+        sub = subparsers.add_parser(command_name)
+        build_func(sub)
+        sub.set_defaults(func=main)
+
+    args = top_parser.parse_args()
+    kwargs = vars(args)
+    log_level = kwargs.pop('log_level')
+
+    setup_logging(log_level)
+    logger = logging.getLogger("beams")
+
+    if hasattr(args, 'func'):
+        func = kwargs.pop('func')
+        logger.debug('%s(**%r)', func.__name__, kwargs)
+        func(**kwargs)
+    else:
+        top_parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/beams/bin/run.py
+++ b/beams/bin/run.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
+
+from beams.tree_config import get_tree_from_path
 
 logger = logging.getLogger(__name__)
 
@@ -29,3 +32,15 @@ def build_arg_parser(argparser=None):
 
 def main(filepath: str):
     logger.info(f"Running behavior tree at {filepath}")
+    # grab config
+    fp = Path(filepath).resolve()
+    if not fp.is_file():
+        raise ValueError("Provided filepath is not a file")
+
+    tree = get_tree_from_path(fp)
+    print(tree)
+    # TODO: the rest of whatever we determine the "run" process to be
+    # run external server?
+    # setup tree?
+    # tick?
+    # settings for ticking? (continuous tick?, as separate process?)

--- a/beams/bin/run.py
+++ b/beams/bin/run.py
@@ -1,0 +1,31 @@
+"""
+`beams run` runs a behavior tree given a configuration file
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        "filepath",
+        type=str,
+        help="Behavior Tree configuration filepath"
+    )
+
+
+def main(filepath: str):
+    logger.info(f"Running behavior tree at {filepath}")

--- a/beams/bin/run.py
+++ b/beams/bin/run.py
@@ -6,9 +6,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
-
-from beams.tree_config import get_tree_from_path
 
 logger = logging.getLogger(__name__)
 
@@ -30,17 +27,6 @@ def build_arg_parser(argparser=None):
     )
 
 
-def main(filepath: str):
-    logger.info(f"Running behavior tree at {filepath}")
-    # grab config
-    fp = Path(filepath).resolve()
-    if not fp.is_file():
-        raise ValueError("Provided filepath is not a file")
-
-    tree = get_tree_from_path(fp)
-    print(tree)
-    # TODO: the rest of whatever we determine the "run" process to be
-    # run external server?
-    # setup tree?
-    # tick?
-    # settings for ticking? (continuous tick?, as separate process?)
+def main(*args, **kwargs):
+    from beams.bin.run_main import main
+    main(*args, **kwargs)

--- a/beams/bin/run_main.py
+++ b/beams/bin/run_main.py
@@ -1,0 +1,26 @@
+"""
+Logic for `superscore run` main
+"""
+
+import logging
+from pathlib import Path
+
+from beams.tree_config import get_tree_from_path
+
+logger = logging.getLogger(__name__)
+
+
+def main(filepath: str):
+    logger.info(f"Running behavior tree at {filepath}")
+    # grab config
+    fp = Path(filepath).resolve()
+    if not fp.is_file():
+        raise ValueError("Provided filepath is not a file")
+
+    tree = get_tree_from_path(fp)
+    print(tree)
+    # TODO: the rest of whatever we determine the "run" process to be
+    # run external server?
+    # setup tree?
+    # tick?
+    # settings for ticking? (continuous tick?, as separate process?)

--- a/beams/logging.py
+++ b/beams/logging.py
@@ -151,6 +151,7 @@ def setup_logging(level: int = logging.INFO):
 
     # set console debug level, log files are always DEBUG
     config["handlers"]["console"]["level"] = level
+    config["loggers"]["beams"]["level"] = level
     logging.config.dictConfig(config)
 
     # setup main logger thread to listen to mp.Process loggers

--- a/beams/logging.yml
+++ b/beams/logging.yml
@@ -1,4 +1,5 @@
 version: 1
+disable_existing_loggers: False
 
 formatters:
   # For the console:
@@ -29,4 +30,5 @@ handlers:
 
 loggers:
   beams:
+    level: INFO
     handlers: [console, debug]

--- a/docs/source/upcoming_release_notes/44-enh_cli.rst
+++ b/docs/source/upcoming_release_notes/44-enh_cli.rst
@@ -1,0 +1,23 @@
+44 enh_cli
+##########
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds cli framework and entrypoint
+
+Bugfixes
+--------
+- Configures logging for the base logger (non Process spawned loggers) and avoids disabling previously created loggers
+- Fix package version handling
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Add a cli framework (that I keep lifting from atef)
- Fix versioning entrypoint (`beams.__version__`)
- Fixes a bit of a logging oversight, don't disable existing loggers when `setup_logging` is called

## Motivation and Context
In partial response to #10 .  When this is in our environment we won't be able to ask users to find the makefile and run commands with it.  This gives us standard python cli entrypoints.  

I could think of a few entrypoints we might add, but didn't want to jump the gun before we discussed them.  
- `beams run`: run a provided tree.  I added this subcommand as an example, but it could use more arguments (tick rate, tick mode {continuous, fixed number, idk}, ...)
- `beams start-server`: start the sequencer server that's currently invoked via `make run_sequencer`
- `beams test_ioc`: start one of the test iocs we have bundled.  Maybe this is replaced by a `caproto` call. 

## How Has This Been Tested?
No new tests added.  interactive testing predominantly

## Where Has This Been Documented?
This PR.

cli is also self-documenting now: 
```bash
$ beams -h
usage: beams [-h] [--version] [--log LOG_LEVEL] {run} ...

`beams` is the top-level command for accessing various subcommands.

    $ beams run --help

positional arguments:
  {run}                 Possible subcommands

optional arguments:
  -h, --help            show this help message and exit
  --version, -V         Show the beams version number and exit.
  --log LOG_LEVEL, -l LOG_LEVEL
                        Python logging level (e.g. DEBUG, INFO, WARNING)
```

```bash
$ beams run -h
usage: beams run [-h] filepath

`beams run` runs a behavior tree given a configuration file

positional arguments:
  filepath    Behavior Tree configuration filepath

optional arguments:
  -h, --help  show this help message and exit
```


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x]  Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
