### PR TITLE
WIP: mfx tree scratchpad

### DIFF
--- a/beams/bin/gen_test_ioc.py
+++ b/beams/bin/gen_test_ioc.py
@@ -1,0 +1,36 @@
+"""
+Generate a test caproto IOC containing all the PVs from a tree set to 0 with no special logic.
+
+Intended usage is something like:
+beams gen_test_ioc my_tree.json > outfile.py
+
+Then, edit outfile.py to set useful starting values and add logic if needed.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        "filepath",
+        type=str,
+        help="Behavior Tree configuration filepath"
+    )
+
+
+def main(*args, **kwargs):
+    from beams.bin.gen_test_ioc_main import main
+    main(*args, **kwargs)

--- a/beams/bin/gen_test_ioc_main.py
+++ b/beams/bin/gen_test_ioc_main.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Iterator
+
+import jinja2
+
+
+def main(
+    filepath: str,
+):
+    with open(filepath, "r") as fd:
+        deser = json.load(fd)
+    all_pvnames = sorted(list(set(pv for pv in walk_dict_pvs(deser))))
+
+    if not all_pvnames:
+        raise RuntimeError(f"Found zero PVs in {filepath}")
+
+    jinja_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(Path(__file__).parent),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = jinja_env.get_template("test_ioc.py.j2")
+    rendered = template.render(all_pvnames=all_pvnames)
+    print(rendered)
+
+
+def walk_dict_pvs(tree_dict: dict) -> Iterator[str]:
+    for key, value in tree_dict.items():
+        if key == "pv" and value:
+            yield value
+        elif isinstance(value, dict):
+            yield from walk_dict_pvs(value)
+        elif isinstance(value, list):
+            for subdict in value:
+                yield from walk_dict_pvs(subdict)

--- a/beams/bin/main.py
+++ b/beams/bin/main.py
@@ -14,6 +14,7 @@ DESCRIPTION = __doc__
 
 COMMAND_TO_MODULE = {
     "run": "run",
+    "gen_test_ioc": "gen_test_ioc",
 }
 
 

--- a/beams/bin/test_ioc.py.j2
+++ b/beams/bin/test_ioc.py.j2
@@ -1,0 +1,24 @@
+from textwrap import dedent
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class BTSimIOC(PVGroup):
+    """
+    An IOC to replicate the PVs used by your behavior tree.
+    """
+{% for pvname in all_pvnames %}
+    {{ pvname.lower().replace(":","_").replace(".","_") }} = pvproperty(
+        value=0,
+        name="{{ pvname }}",
+        doc="Fake {{ pvname }}",
+    )
+{% endfor %}
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='',
+        desc=dedent(BTSimIOC.__doc__))
+    ioc = BTSimIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/beams/bin/test_ioc.py.j2
+++ b/beams/bin/test_ioc.py.j2
@@ -17,6 +17,9 @@ class BTSimIOC(PVGroup):
 
 
 if __name__ == '__main__':
+    # Default is 5064, switch to 5066 to avoid conflict with prod
+    # Set this in terminal before you run your tree too to connect to this sim
+    os.environ["EPICS_CA_SERVER_PORT"] = "5066"
     ioc_options, run_options = ioc_arg_parser(
         default_prefix='',
         desc=dedent(BTSimIOC.__doc__))

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -210,7 +210,7 @@ class RangeConditionItem(BaseItem):
     """
     Shorthand for a sequence of two condition items, establishing a range.
     """
-    memory: bool = False,
+    memory: bool = False
     pv: str = ""
     low_value: Any = 0
     high_value: Any = 1,

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -332,7 +332,7 @@ class CheckAndDoItem(BaseItem):
     def __post_init__(self):
         # Clearly indicate the intent for serialization
         # If no termination check, use the check's check
-        if self.do.termination_check.pv == "":
+        if not self.do.termination_check.name:
             self.do.termination_check = UseCheckConditionItem()
 
     def get_tree(self) -> CheckAndDo:

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -257,12 +257,8 @@ class SetPVActionItem(BaseItem):
 
         def work_func(comp_condition: Callable[[], bool]):
             try:
-                # Set to running
-                value = caget(self.termination_check.pv)
-
                 if comp_condition():
                     return py_trees.common.Status.SUCCESS
-                logger.debug(f"{self.name}: Value is {value}")
 
                 # specific caput logic to SetPVActionItem
                 caput(self.pv, self.value)

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -107,14 +107,7 @@ class SelectorItem(BaseItem):
         return node
 
 
-class ImplementsSequence(Protocol):
-    name: str
-    description: str
-    memory: bool
-    children: List[BaseItem]
-
-
-def get_sequence_tree(seq_item: ImplementsSequence):
+def get_sequence_tree(seq_item: AnySequenceItem):
     children = []
     for child in seq_item.children:
         children.append(child.get_tree())
@@ -180,7 +173,7 @@ class SequenceConditionItem(BaseItem):
     like a normal Sequence Item.
     """
     memory: bool = False
-    children: List[ConditionItem] = field(default_factory=list)
+    children: List[AnyConditionItem] = field(default_factory=list)
 
     def get_tree(self) -> Sequence:
         return get_sequence_tree(self)
@@ -242,16 +235,13 @@ class RangeConditionItem(BaseItem):
         return self._generate_subconfig().get_condition_function()
 
 
-AnyCondition = Union[ConditionItem, SequenceConditionItem, RangeConditionItem]
-
-
 @dataclass
 class SetPVActionItem(BaseItem):
     pv: str = ""
     value: Any = 1
     loop_period_sec: float = 1.0
 
-    termination_check: AnyCondition = field(default_factory=ConditionItem)
+    termination_check: AnyConditionItem = field(default_factory=ConditionItem)
 
     def get_tree(self) -> ActionNode:
 
@@ -289,7 +279,7 @@ class IncPVActionItem(BaseItem):
     increment: float = 1
     loop_period_sec: float = 1.0
 
-    termination_check: AnyCondition = field(default_factory=ConditionItem)
+    termination_check: AnyConditionItem = field(default_factory=ConditionItem)
 
     def get_tree(self) -> ActionNode:
 
@@ -326,7 +316,7 @@ class IncPVActionItem(BaseItem):
 
 @dataclass
 class CheckAndDoItem(BaseItem):
-    check: AnyCondition = field(default_factory=ConditionItem)
+    check: AnyConditionItem = field(default_factory=ConditionItem)
     do: Union[SetPVActionItem, IncPVActionItem] = field(default_factory=SetPVActionItem)
 
     def __post_init__(self):
@@ -456,3 +446,7 @@ class WaitForBlackboardVariableValueItem(BaseItem):
             operator=getattr(operator, self.check.operator.value)
         )
         return WaitForBlackboardVariableValue(name=self.name, check=comp_exp)
+
+
+AnyConditionItem = Union[ConditionItem, SequenceConditionItem, RangeConditionItem]
+AnySequenceItem = Union[SequenceItem, SequenceConditionItem]

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
 import py_trees
-from apischema import deserialize
+from apischema import deserialize, serialize
 from epics import caget, caput
 from py_trees.behaviour import Behaviour
 from py_trees.behaviours import (CheckBlackboardVariableValue,
@@ -26,13 +26,21 @@ from beams.serialization import as_tagged_union
 logger = logging.getLogger(__name__)
 
 
-def get_tree_from_path(path: Path) -> py_trees.trees.BehaviourTree:
+def get_tree_from_path(path: Union[Path, str]) -> py_trees.trees.BehaviourTree:
     """Deserialize a json file, return the tree it specifies"""
     with open(path, "r") as fd:
         deser = json.load(fd)
         tree_item = deserialize(BehaviorTreeItem, deser)
 
     return tree_item.get_tree()
+
+
+def save_tree_to_path(path: Union[Path, str], root: BaseItem):
+    """Serialize a behavior tree node to a json file."""
+    ser = serialize(BehaviorTreeItem(root=root))
+
+    with open(path, "w") as fd:
+        json.dump(ser, fd, indent=2)
 
 
 @dataclass

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import operator
 import time
+from copy import copy
 from dataclasses import dataclass, field, fields
 from enum import Enum
 from pathlib import Path
@@ -41,6 +42,7 @@ def save_tree_to_path(path: Union[Path, str], root: BaseItem):
 
     with open(path, "w") as fd:
         json.dump(ser, fd, indent=2)
+        fd.write("\n")
 
 
 @dataclass
@@ -328,17 +330,32 @@ class CheckAndDoItem(BaseItem):
     do: Union[SetPVActionItem, IncPVActionItem] = field(default_factory=SetPVActionItem)
 
     def __post_init__(self):
-        # Allow shorthand of not setting do.termination_check
-        if not self.do.termination_check.pv:
-            self.do.termination_check = self.check
+        # Clearly indicate the intent for serialization
+        # If no termination check, use the check's check
+        if self.do.termination_check.pv == "":
+            self.do.termination_check = UseCheckConditionItem()
 
     def get_tree(self) -> CheckAndDo:
+        if isinstance(self.do.termination_check, UseCheckConditionItem):
+            active_do = copy(self.do)
+            active_do.termination_check = self.check
+        else:
+            active_do = self.do
+
         check_node = self.check.get_tree()
-        do_node = self.do.get_tree()
+        do_node = active_do.get_tree()
 
         node = CheckAndDo(name=self.name, check=check_node, do=do_node)
 
         return node
+
+
+@dataclass
+class UseCheckConditionItem(BaseItem):
+    """
+    Dummy item: indicates that check and do should use "check" as do's termination check.
+    """
+    copy_from: str = "previous check"
 
 
 # py_trees.behaviours Behaviour items
@@ -456,5 +473,5 @@ class WaitForBlackboardVariableValueItem(BaseItem):
         return WaitForBlackboardVariableValue(name=self.name, check=comp_exp)
 
 
-AnyConditionItem = Union[ConditionItem, SequenceConditionItem, RangeConditionItem]
+AnyConditionItem = Union[ConditionItem, SequenceConditionItem, RangeConditionItem, UseCheckConditionItem]
 AnySequenceItem = Union[SequenceItem, SequenceConditionItem]

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass, field, fields
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union, Protocol
+from typing import Any, Callable, List, Optional, Union
 
 import py_trees
 from apischema import deserialize
@@ -180,7 +180,7 @@ class SequenceConditionItem(BaseItem):
 
     def get_condition_function(self) -> Callable[[], bool]:
         child_funcs = [item.get_condition_function() for item in self.children]
-        
+
         def cond_func():
             """
             Minimize network hits by failing at first issue
@@ -230,7 +230,7 @@ class RangeConditionItem(BaseItem):
 
     def get_tree(self) -> Sequence:
         return self._generate_subconfig().get_tree()
-    
+
     def get_condition_function(self) -> Callable[[], bool]:
         return self._generate_subconfig().get_condition_function()
 

--- a/mfx_sim.py
+++ b/mfx_sim.py
@@ -1,0 +1,212 @@
+from textwrap import dedent
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class BTSimIOC(PVGroup):
+    """
+    An IOC to replicate the PVs used by your behavior tree.
+    """
+    hfx_dg2_stp_01_close = pvproperty(
+        value=0,
+        name="HFX:DG2:STP:01:CLOSE",
+        doc="Fake HFX:DG2:STP:01:CLOSE",
+    )
+    hfx_dg2_stp_01_cmd = pvproperty(
+        value=0,
+        name="HFX:DG2:STP:01:CMD",
+        doc="Fake HFX:DG2:STP:01:CMD",
+    )
+    hfx_dg2_stp_01_open = pvproperty(
+        value=0,
+        name="HFX:DG2:STP:01:OPEN",
+        doc="Fake HFX:DG2:STP:01:OPEN",
+    )
+    mfx_att_com_calcp = pvproperty(
+        value=0,
+        name="MFX:ATT:COM:CALCP",
+        doc="Fake MFX:ATT:COM:CALCP",
+    )
+    mfx_att_com_go = pvproperty(
+        value=0,
+        name="MFX:ATT:COM:GO",
+        doc="Fake MFX:ATT:COM:GO",
+    )
+    mfx_att_com_r_cur = pvproperty(
+        value=0,
+        name="MFX:ATT:COM:R_CUR",
+        doc="Fake MFX:ATT:COM:R_CUR",
+    )
+    mfx_att_com_r_des = pvproperty(
+        value=0,
+        name="MFX:ATT:COM:R_DES",
+        doc="Fake MFX:ATT:COM:R_DES",
+    )
+    mfx_dg1_jaws_actual_xwidth = pvproperty(
+        value=0,
+        name="MFX:DG1:JAWS:Actual_XWIDTH",
+        doc="Fake MFX:DG1:JAWS:Actual_XWIDTH",
+    )
+    mfx_dg1_jaws_actual_ywidth = pvproperty(
+        value=0,
+        name="MFX:DG1:JAWS:Actual_YWIDTH",
+        doc="Fake MFX:DG1:JAWS:Actual_YWIDTH",
+    )
+    mfx_dg1_jaws_xwid_req = pvproperty(
+        value=0,
+        name="MFX:DG1:JAWS:XWID_REQ",
+        doc="Fake MFX:DG1:JAWS:XWID_REQ",
+    )
+    mfx_dg1_jaws_ywid_req = pvproperty(
+        value=0,
+        name="MFX:DG1:JAWS:YWID_REQ",
+        doc="Fake MFX:DG1:JAWS:YWID_REQ",
+    )
+    mfx_dg1_p6740_acquire = pvproperty(
+        value=0,
+        name="MFX:DG1:P6740:Acquire",
+        doc="Fake MFX:DG1:P6740:Acquire",
+    )
+    mfx_dg1_p6740_arrayrate_rbv = pvproperty(
+        value=0,
+        name="MFX:DG1:P6740:ArrayRate_RBV",
+        doc="Fake MFX:DG1:P6740:ArrayRate_RBV",
+    )
+    mfx_dg1_pim = pvproperty(
+        value=0,
+        name="MFX:DG1:PIM",
+        doc="Fake MFX:DG1:PIM",
+    )
+    mfx_dg1_pim_go = pvproperty(
+        value=0,
+        name="MFX:DG1:PIM:GO",
+        doc="Fake MFX:DG1:PIM:GO",
+    )
+    mfx_dg2_jaws_ds_actual_xwidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:DS:Actual_XWIDTH",
+        doc="Fake MFX:DG2:JAWS:DS:Actual_XWIDTH",
+    )
+    mfx_dg2_jaws_ds_actual_ywidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:DS:Actual_YWIDTH",
+        doc="Fake MFX:DG2:JAWS:DS:Actual_YWIDTH",
+    )
+    mfx_dg2_jaws_ds_xwid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:DS:XWID_REQ",
+        doc="Fake MFX:DG2:JAWS:DS:XWID_REQ",
+    )
+    mfx_dg2_jaws_ds_ywid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:DS:YWID_REQ",
+        doc="Fake MFX:DG2:JAWS:DS:YWID_REQ",
+    )
+    mfx_dg2_jaws_ms_actual_xwidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:MS:Actual_XWIDTH",
+        doc="Fake MFX:DG2:JAWS:MS:Actual_XWIDTH",
+    )
+    mfx_dg2_jaws_ms_actual_ywidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:MS:Actual_YWIDTH",
+        doc="Fake MFX:DG2:JAWS:MS:Actual_YWIDTH",
+    )
+    mfx_dg2_jaws_ms_xwid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:MS:XWID_REQ",
+        doc="Fake MFX:DG2:JAWS:MS:XWID_REQ",
+    )
+    mfx_dg2_jaws_ms_ywid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:MS:YWID_REQ",
+        doc="Fake MFX:DG2:JAWS:MS:YWID_REQ",
+    )
+    mfx_dg2_jaws_us_actual_xwidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:US:Actual_XWIDTH",
+        doc="Fake MFX:DG2:JAWS:US:Actual_XWIDTH",
+    )
+    mfx_dg2_jaws_us_actual_ywidth = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:US:Actual_YWIDTH",
+        doc="Fake MFX:DG2:JAWS:US:Actual_YWIDTH",
+    )
+    mfx_dg2_jaws_us_xwid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:US:XWID_REQ",
+        doc="Fake MFX:DG2:JAWS:US:XWID_REQ",
+    )
+    mfx_dg2_jaws_us_ywid_req = pvproperty(
+        value=0,
+        name="MFX:DG2:JAWS:US:YWID_REQ",
+        doc="Fake MFX:DG2:JAWS:US:YWID_REQ",
+    )
+    mfx_dg2_pim = pvproperty(
+        value=0,
+        name="MFX:DG2:PIM",
+        doc="Fake MFX:DG2:PIM",
+    )
+    mfx_dg2_pim_go = pvproperty(
+        value=0,
+        name="MFX:DG2:PIM:GO",
+        doc="Fake MFX:DG2:PIM:GO",
+    )
+    mfx_lens_dia_01 = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:01",
+        doc="Fake MFX:LENS:DIA:01",
+    )
+    mfx_lens_dia_01_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:01:REMOVE",
+        doc="Fake MFX:LENS:DIA:01:REMOVE",
+    )
+    mfx_lens_dia_02 = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:02",
+        doc="Fake MFX:LENS:DIA:02",
+    )
+    mfx_lens_dia_02_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:02:REMOVE",
+        doc="Fake MFX:LENS:DIA:02:REMOVE",
+    )
+    mfx_lens_dia_03 = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:03",
+        doc="Fake MFX:LENS:DIA:03",
+    )
+    mfx_lens_dia_03_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:03:REMOVE",
+        doc="Fake MFX:LENS:DIA:03:REMOVE",
+    )
+    mr1l4_homs_mms_pitch_rbv = pvproperty(
+        value=0,
+        name="MR1L4:HOMS:MMS:PITCH.RBV",
+        doc="Fake MR1L4:HOMS:MMS:PITCH.RBV",
+    )
+    mr1l4_homs_mms_pitch_val = pvproperty(
+        value=0,
+        name="MR1L4:HOMS:MMS:PITCH.VAL",
+        doc="Fake MR1L4:HOMS:MMS:PITCH.VAL",
+    )
+    mr1l4_homs_mms_xup_state_get_rbv = pvproperty(
+        value=0,
+        name="MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
+        doc="Fake MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
+    )
+    mr1l4_homs_mms_xup_state_set = pvproperty(
+        value=0,
+        name="MR1L4:HOMS:MMS:XUP:STATE:SET",
+        doc="Fake MR1L4:HOMS:MMS:XUP:STATE:SET",
+    )
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='',
+        desc=dedent(BTSimIOC.__doc__))
+    ioc = BTSimIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/mfx_sim.py
+++ b/mfx_sim.py
@@ -18,7 +18,7 @@ class BTSimIOC(PVGroup):
         doc="Fake HFX:DG2:STP:01:CMD",
     )
     hfx_dg2_stp_01_open = pvproperty(
-        value=0,
+        value=1,
         name="HFX:DG2:STP:01:OPEN",
         doc="Fake HFX:DG2:STP:01:OPEN",
     )
@@ -33,129 +33,129 @@ class BTSimIOC(PVGroup):
         doc="Fake MFX:ATT:COM:GO",
     )
     mfx_att_com_r_cur = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:ATT:COM:R_CUR",
         doc="Fake MFX:ATT:COM:R_CUR",
     )
     mfx_att_com_r_des = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:ATT:COM:R_DES",
         doc="Fake MFX:ATT:COM:R_DES",
     )
     mfx_dg1_jaws_actual_xwidth = pvproperty(
-        value=0,
+        value=5.0,
         name="MFX:DG1:JAWS:Actual_XWIDTH",
         doc="Fake MFX:DG1:JAWS:Actual_XWIDTH",
     )
     mfx_dg1_jaws_actual_ywidth = pvproperty(
-        value=0,
+        value=5.0,
         name="MFX:DG1:JAWS:Actual_YWIDTH",
         doc="Fake MFX:DG1:JAWS:Actual_YWIDTH",
     )
     mfx_dg1_jaws_xwid_req = pvproperty(
-        value=0,
+        value=5.0,
         name="MFX:DG1:JAWS:XWID_REQ",
         doc="Fake MFX:DG1:JAWS:XWID_REQ",
     )
     mfx_dg1_jaws_ywid_req = pvproperty(
-        value=0,
+        value=5.0,
         name="MFX:DG1:JAWS:YWID_REQ",
         doc="Fake MFX:DG1:JAWS:YWID_REQ",
     )
     mfx_dg1_p6740_acquire = pvproperty(
-        value=0,
+        value=1,
         name="MFX:DG1:P6740:Acquire",
         doc="Fake MFX:DG1:P6740:Acquire",
     )
     mfx_dg1_p6740_arrayrate_rbv = pvproperty(
-        value=0,
+        value=0.0,
         name="MFX:DG1:P6740:ArrayRate_RBV",
         doc="Fake MFX:DG1:P6740:ArrayRate_RBV",
     )
     mfx_dg1_pim = pvproperty(
-        value=0,
+        value="OUT",
         name="MFX:DG1:PIM",
         doc="Fake MFX:DG1:PIM",
     )
     mfx_dg1_pim_go = pvproperty(
-        value=0,
+        value="OUT",
         name="MFX:DG1:PIM:GO",
         doc="Fake MFX:DG1:PIM:GO",
     )
     mfx_dg2_jaws_ds_actual_xwidth = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:DG2:JAWS:DS:Actual_XWIDTH",
         doc="Fake MFX:DG2:JAWS:DS:Actual_XWIDTH",
     )
     mfx_dg2_jaws_ds_actual_ywidth = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:DG2:JAWS:DS:Actual_YWIDTH",
         doc="Fake MFX:DG2:JAWS:DS:Actual_YWIDTH",
     )
     mfx_dg2_jaws_ds_xwid_req = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:DG2:JAWS:DS:XWID_REQ",
         doc="Fake MFX:DG2:JAWS:DS:XWID_REQ",
     )
     mfx_dg2_jaws_ds_ywid_req = pvproperty(
-        value=0,
+        value=1.0,
         name="MFX:DG2:JAWS:DS:YWID_REQ",
         doc="Fake MFX:DG2:JAWS:DS:YWID_REQ",
     )
     mfx_dg2_jaws_ms_actual_xwidth = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:MS:Actual_XWIDTH",
         doc="Fake MFX:DG2:JAWS:MS:Actual_XWIDTH",
     )
     mfx_dg2_jaws_ms_actual_ywidth = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:MS:Actual_YWIDTH",
         doc="Fake MFX:DG2:JAWS:MS:Actual_YWIDTH",
     )
     mfx_dg2_jaws_ms_xwid_req = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:MS:XWID_REQ",
         doc="Fake MFX:DG2:JAWS:MS:XWID_REQ",
     )
     mfx_dg2_jaws_ms_ywid_req = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:MS:YWID_REQ",
         doc="Fake MFX:DG2:JAWS:MS:YWID_REQ",
     )
     mfx_dg2_jaws_us_actual_xwidth = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:US:Actual_XWIDTH",
         doc="Fake MFX:DG2:JAWS:US:Actual_XWIDTH",
     )
     mfx_dg2_jaws_us_actual_ywidth = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:US:Actual_YWIDTH",
         doc="Fake MFX:DG2:JAWS:US:Actual_YWIDTH",
     )
     mfx_dg2_jaws_us_xwid_req = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:US:XWID_REQ",
         doc="Fake MFX:DG2:JAWS:US:XWID_REQ",
     )
     mfx_dg2_jaws_us_ywid_req = pvproperty(
-        value=0,
+        value=0.5,
         name="MFX:DG2:JAWS:US:YWID_REQ",
         doc="Fake MFX:DG2:JAWS:US:YWID_REQ",
     )
     mfx_dg2_pim = pvproperty(
-        value=0,
+        value="OUT",
         name="MFX:DG2:PIM",
         doc="Fake MFX:DG2:PIM",
     )
     mfx_dg2_pim_go = pvproperty(
-        value=0,
+        value="OUT",
         name="MFX:DG2:PIM:GO",
         doc="Fake MFX:DG2:PIM:GO",
     )
     mfx_lens_dia_01 = pvproperty(
-        value=0,
-        name="MFX:LENS:DIA:01",
-        doc="Fake MFX:LENS:DIA:01",
+        value=1,
+        name="MFX:LENS:DIA:01:STATE",
+        doc="Fake MFX:LENS:DIA:01:STATE",
     )
     mfx_lens_dia_01_remove = pvproperty(
         value=0,
@@ -164,8 +164,8 @@ class BTSimIOC(PVGroup):
     )
     mfx_lens_dia_02 = pvproperty(
         value=0,
-        name="MFX:LENS:DIA:02",
-        doc="Fake MFX:LENS:DIA:02",
+        name="MFX:LENS:DIA:02:STATE",
+        doc="Fake MFX:LENS:DIA:02:STATE",
     )
     mfx_lens_dia_02_remove = pvproperty(
         value=0,
@@ -174,8 +174,8 @@ class BTSimIOC(PVGroup):
     )
     mfx_lens_dia_03 = pvproperty(
         value=0,
-        name="MFX:LENS:DIA:03",
-        doc="Fake MFX:LENS:DIA:03",
+        name="MFX:LENS:DIA:03:STATE",
+        doc="Fake MFX:LENS:DIA:03:STATE",
     )
     mfx_lens_dia_03_remove = pvproperty(
         value=0,
@@ -183,22 +183,22 @@ class BTSimIOC(PVGroup):
         doc="Fake MFX:LENS:DIA:03:REMOVE",
     )
     mr1l4_homs_mms_pitch_rbv = pvproperty(
-        value=0,
+        value=833.4,
         name="MR1L4:HOMS:MMS:PITCH.RBV",
         doc="Fake MR1L4:HOMS:MMS:PITCH.RBV",
     )
     mr1l4_homs_mms_pitch_val = pvproperty(
-        value=0,
+        value=833.4,
         name="MR1L4:HOMS:MMS:PITCH.VAL",
         doc="Fake MR1L4:HOMS:MMS:PITCH.VAL",
     )
     mr1l4_homs_mms_xup_state_get_rbv = pvproperty(
-        value=0,
+        value="OUT",
         name="MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
         doc="Fake MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
     )
     mr1l4_homs_mms_xup_state_set = pvproperty(
-        value=0,
+        value="OUT",
         name="MR1L4:HOMS:MMS:XUP:STATE:SET",
         doc="Fake MR1L4:HOMS:MMS:XUP:STATE:SET",
     )

--- a/mfx_sim.py
+++ b/mfx_sim.py
@@ -1,3 +1,4 @@
+import os
 from textwrap import dedent
 
 from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
@@ -305,6 +306,9 @@ class BTSimIOC(PVGroup):
 
 
 if __name__ == '__main__':
+    # Default is 5064, switch to 5066 to avoid conflict with prod
+    # Set this in terminal before you run your tree too to connect to this sim
+    os.environ["EPICS_CA_SERVER_PORT"] = "5066"
     ioc_options, run_options = ioc_arg_parser(
         default_prefix='',
         desc=dedent(BTSimIOC.__doc__))

--- a/mfx_sim.py
+++ b/mfx_sim.py
@@ -152,35 +152,135 @@ class BTSimIOC(PVGroup):
         name="MFX:DG2:PIM:GO",
         doc="Fake MFX:DG2:PIM:GO",
     )
-    mfx_lens_dia_01 = pvproperty(
-        value=1,
-        name="MFX:LENS:DIA:01:STATE",
-        doc="Fake MFX:LENS:DIA:01:STATE",
-    )
     mfx_lens_dia_01_remove = pvproperty(
         value=0,
         name="MFX:LENS:DIA:01:REMOVE",
         doc="Fake MFX:LENS:DIA:01:REMOVE",
     )
-    mfx_lens_dia_02 = pvproperty(
-        value=0,
-        name="MFX:LENS:DIA:02:STATE",
-        doc="Fake MFX:LENS:DIA:02:STATE",
+    mfx_lens_dia_01_state = pvproperty(
+        value=1,
+        name="MFX:LENS:DIA:01:STATE",
+        doc="Fake MFX:LENS:DIA:01:STATE",
     )
     mfx_lens_dia_02_remove = pvproperty(
         value=0,
         name="MFX:LENS:DIA:02:REMOVE",
         doc="Fake MFX:LENS:DIA:02:REMOVE",
     )
-    mfx_lens_dia_03 = pvproperty(
+    mfx_lens_dia_02_state = pvproperty(
         value=0,
-        name="MFX:LENS:DIA:03:STATE",
-        doc="Fake MFX:LENS:DIA:03:STATE",
+        name="MFX:LENS:DIA:02:STATE",
+        doc="Fake MFX:LENS:DIA:02:STATE",
     )
     mfx_lens_dia_03_remove = pvproperty(
         value=0,
         name="MFX:LENS:DIA:03:REMOVE",
         doc="Fake MFX:LENS:DIA:03:REMOVE",
+    )
+    mfx_lens_dia_03_state = pvproperty(
+        value=0,
+        name="MFX:LENS:DIA:03:STATE",
+        doc="Fake MFX:LENS:DIA:03:STATE",
+    )
+    mfx_lens_tfs_01_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:01:REMOVE",
+        doc="Fake MFX:LENS:TFS:01:REMOVE",
+    )
+    mfx_lens_tfs_01_state = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:01:STATE",
+        doc="Fake MFX:LENS:TFS:01:STATE",
+    )
+    mfx_lens_tfs_02_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:02:REMOVE",
+        doc="Fake MFX:LENS:TFS:02:REMOVE",
+    )
+    mfx_lens_tfs_02_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:02:STATE",
+        doc="Fake MFX:LENS:TFS:02:STATE",
+    )
+    mfx_lens_tfs_03_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:03:REMOVE",
+        doc="Fake MFX:LENS:TFS:03:REMOVE",
+    )
+    mfx_lens_tfs_03_state = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:03:STATE",
+        doc="Fake MFX:LENS:TFS:03:STATE",
+    )
+    mfx_lens_tfs_04_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:04:REMOVE",
+        doc="Fake MFX:LENS:TFS:04:REMOVE",
+    )
+    mfx_lens_tfs_04_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:04:STATE",
+        doc="Fake MFX:LENS:TFS:04:STATE",
+    )
+    mfx_lens_tfs_05_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:05:REMOVE",
+        doc="Fake MFX:LENS:TFS:05:REMOVE",
+    )
+    mfx_lens_tfs_05_state = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:05:STATE",
+        doc="Fake MFX:LENS:TFS:05:STATE",
+    )
+    mfx_lens_tfs_06_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:06:REMOVE",
+        doc="Fake MFX:LENS:TFS:06:REMOVE",
+    )
+    mfx_lens_tfs_06_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:06:STATE",
+        doc="Fake MFX:LENS:TFS:06:STATE",
+    )
+    mfx_lens_tfs_07_remove = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:07:REMOVE",
+        doc="Fake MFX:LENS:TFS:07:REMOVE",
+    )
+    mfx_lens_tfs_07_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:07:STATE",
+        doc="Fake MFX:LENS:TFS:07:STATE",
+    )
+    mfx_lens_tfs_08_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:08:REMOVE",
+        doc="Fake MFX:LENS:TFS:08:REMOVE",
+    )
+    mfx_lens_tfs_08_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:08:STATE",
+        doc="Fake MFX:LENS:TFS:08:STATE",
+    )
+    mfx_lens_tfs_09_remove = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:09:REMOVE",
+        doc="Fake MFX:LENS:TFS:09:REMOVE",
+    )
+    mfx_lens_tfs_09_state = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:09:STATE",
+        doc="Fake MFX:LENS:TFS:09:STATE",
+    )
+    mfx_lens_tfs_10_remove = pvproperty(
+        value=0,
+        name="MFX:LENS:TFS:10:REMOVE",
+        doc="Fake MFX:LENS:TFS:10:REMOVE",
+    )
+    mfx_lens_tfs_10_state = pvproperty(
+        value=1,
+        name="MFX:LENS:TFS:10:STATE",
+        doc="Fake MFX:LENS:TFS:10:STATE",
     )
     mr1l4_homs_mms_pitch_rbv = pvproperty(
         value=833.4,

--- a/mfx_tree.json
+++ b/mfx_tree.json
@@ -1,0 +1,775 @@
+{
+  "root": {
+    "SequenceItem": {
+      "name": "dg1_prep",
+      "description": "Prepare MFX for alignment to DG1",
+      "memory": false,
+      "children": [
+        {
+          "CheckAndDoItem": {
+            "name": "dg2_stopper",
+            "description": "Ensure that dg2 is inserted before moving focusing optics.",
+            "check": {
+              "name": "check_dg2_stp_in",
+              "description": "Check that dg2 stopper is at the closed switch but not at the open switch.",
+              "memory": false,
+              "children": [
+                {
+                  "name": "check_dg2_stp_closed",
+                  "description": "Check that dg2 stopper is at closed switch.",
+                  "pv": "HFX:DG2:STP:01:CLOSE",
+                  "value": 1,
+                  "operator": "eq"
+                },
+                {
+                  "name": "check_dg2_stp_not_open",
+                  "description": "Check that dg2 stopper is not at open switch.",
+                  "pv": "HFX:DG2:STP:01:OPEN",
+                  "value": 0,
+                  "operator": "eq"
+                }
+              ]
+            },
+            "do": {
+              "name": "act_close_dg2_stp",
+              "description": "Move dg2 stopper to block the beam.",
+              "pv": "HFX:DG2:STP:01:CMD",
+              "value": 2,
+              "loop_period_sec": 1.0,
+              "termination_check": {
+                "name": "check_dg2_stp_in",
+                "description": "Check that dg2 stopper is at the closed switch but not at the open switch.",
+                "memory": false,
+                "children": [
+                  {
+                    "name": "check_dg2_stp_closed",
+                    "description": "Check that dg2 stopper is at closed switch.",
+                    "pv": "HFX:DG2:STP:01:CLOSE",
+                    "value": 1,
+                    "operator": "eq"
+                  },
+                  {
+                    "name": "check_dg2_stp_not_open",
+                    "description": "Check that dg2 stopper is not at open switch.",
+                    "pv": "HFX:DG2:STP:01:OPEN",
+                    "value": 0,
+                    "operator": "eq"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "SequenceItem": {
+            "name": "prefocus_remove",
+            "description": "ensure all prefocusing lenses are removed",
+            "memory": false,
+            "children": [
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl1_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl1_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:01",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl1_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:01:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl1_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:01",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl2_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl2_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:02",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl2_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:02:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl2_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:02",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl3_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl3_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:03",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl3_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:03:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl3_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:03",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "SequenceItem": {
+            "name": "transfocator_remove",
+            "description": "ensure all transfocator lenses are removed",
+            "memory": false,
+            "children": [
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl1_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl1_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:01",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl1_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:01:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl1_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:01",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl2_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl2_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:02",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl2_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:02:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl2_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:02",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_pfl3_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_pfl3_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:DIA:03",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_pfl3_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:DIA:03:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_pfl3_out",
+                      "description": "Check if lens is removed",
+                      "pv": "MFX:LENS:DIA:03",
+                      "value": 0,
+                      "operator": "eq"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "CheckAndDoItem": {
+            "name": "dg1_yag",
+            "description": "Ensure dg1_yag is inserted",
+            "check": {
+              "name": "check_dg1_yag_in",
+              "description": "Check if the dg1 yag is in",
+              "pv": "MFX:DG1:PIM",
+              "value": "YAG",
+              "operator": "eq"
+            },
+            "do": {
+              "name": "act_insert_dg1_yag",
+              "description": "Insert dg1 yag",
+              "pv": "MFX:DG1:PIM:GO",
+              "value": "YAG",
+              "loop_period_sec": 1.0,
+              "termination_check": {
+                "name": "check_dg1_yag_in",
+                "description": "Check if the dg1 yag is in",
+                "pv": "MFX:DG1:PIM",
+                "value": "YAG",
+                "operator": "eq"
+              }
+            }
+          }
+        },
+        {
+          "CheckAndDoItem": {
+            "name": "d2_yag",
+            "description": "Ensure dg2_yag is inserted",
+            "check": {
+              "name": "check_dg2_yag_in",
+              "description": "Check if the dg2 yag is in",
+              "pv": "MFX:DG2:PIM",
+              "value": "YAG",
+              "operator": "eq"
+            },
+            "do": {
+              "name": "act_insert_dg2_yag",
+              "description": "Insert dg2 yag",
+              "pv": "MFX:DG2:PIM:GO",
+              "value": "YAG",
+              "loop_period_sec": 1.0,
+              "termination_check": {
+                "name": "check_dg2_yag_in",
+                "description": "Check if the dg2 yag is in",
+                "pv": "MFX:DG2:PIM",
+                "value": "YAG",
+                "operator": "eq"
+              }
+            }
+          }
+        },
+        {
+          "SelectorItem": {
+            "name": "mfx_att",
+            "description": "Ensure mfx att is near 10% transmission for alignment",
+            "memory": false,
+            "children": [
+              {
+                "RangeConditionItem": {
+                  "name": "check_mfx_att_range",
+                  "description": "Check if mfx_att is near 10% transmission",
+                  "memory": [
+                    false
+                  ],
+                  "pv": "MFX:ATT:COM:R_CUR",
+                  "low_value": 0.08,
+                  "high_value": 0.12
+                }
+              },
+              {
+                "SequenceItem": {
+                  "name": "seq_set_mfx_att",
+                  "description": "Set the mfx att to 10% transmission",
+                  "memory": false,
+                  "children": [
+                    {
+                      "ConditionItem": {
+                        "name": "check_calc_ready",
+                        "description": "Wait for previous or current calc to be done",
+                        "pv": "MFX:ATT:COM:CALCP",
+                        "value": 0,
+                        "operator": "eq"
+                      }
+                    },
+                    {
+                      "SetPVActionItem": {
+                        "name": "act_prepare_transmission",
+                        "description": "Set the transmission that will be applied",
+                        "pv": "MFX:ATT:COM:R_DES",
+                        "value": 0.1,
+                        "loop_period_sec": 1.0,
+                        "termination_check": {
+                          "name": "",
+                          "description": "",
+                          "pv": "",
+                          "value": 1,
+                          "operator": "eq"
+                        }
+                      }
+                    },
+                    {
+                      "SetPVActionItem": {
+                        "name": "act_apply_transmission",
+                        "description": "Move the attenuator to the lesser of the two att options",
+                        "pv": "MFX:ATT:COM:GO",
+                        "value": 3,
+                        "loop_period_sec": 1.0,
+                        "termination_check": {
+                          "name": "check_mfx_att_range",
+                          "description": "Check if mfx_att is near 10% transmission",
+                          "memory": [
+                            false
+                          ],
+                          "pv": "MFX:ATT:COM:R_CUR",
+                          "low_value": 0.08,
+                          "high_value": 0.12
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "SequenceItem": {
+            "name": "slits_to_2mm",
+            "description": "Ensure all slit widths are close to 2mm",
+            "memory": false,
+            "children": [
+              {
+                "CheckAndDoItem": {
+                  "name": "dg1_x_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg1_x_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG1:JAWS:Actual_XWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg1_x_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG1:JAWS:XWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg1_x_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG1:JAWS:Actual_XWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg1_y_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg1_y_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG1:JAWS:Actual_YWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg1_y_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG1:JAWS:YWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg1_y_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG1:JAWS:Actual_YWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_us_x_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_us_x_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:US:Actual_XWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_us_x_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:US:XWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_us_x_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:US:Actual_XWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_us_y_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_us_y_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:US:Actual_YWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_us_y_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:US:YWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_us_y_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:US:Actual_YWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_ms_x_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_ms_x_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:MS:Actual_XWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_ms_x_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:MS:XWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_ms_x_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:MS:Actual_XWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_ms_y_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_ms_y_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:MS:Actual_YWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_ms_y_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:MS:YWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_ms_y_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:MS:Actual_YWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_ds_x_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_ds_x_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:DS:Actual_XWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_ds_x_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:DS:XWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_ds_x_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:DS:Actual_XWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "dg2_ds_y_check_and_do",
+                  "description": "Ensure slit width is close to 2mm",
+                  "check": {
+                    "name": "dg2_ds_y_check",
+                    "description": "Check if slit width is close to 2mm",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MFX:DG2:JAWS:DS:Actual_YWIDTH",
+                    "low_value": 1.9,
+                    "high_value": 2.1
+                  },
+                  "do": {
+                    "name": "dg2_ds_y_move",
+                    "description": "Move slit width to 2mm",
+                    "pv": "MFX:DG2:JAWS:DS:YWID_REQ",
+                    "value": 2,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "dg2_ds_y_check",
+                      "description": "Check if slit width is close to 2mm",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MFX:DG2:JAWS:DS:Actual_YWIDTH",
+                      "low_value": 1.9,
+                      "high_value": 2.1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "SequenceItem": {
+            "name": "prepare_mr1l4",
+            "description": "Get mr1l4 ready for MFX beam",
+            "memory": false,
+            "children": [
+              {
+                "CheckAndDoItem": {
+                  "name": "insert_mr1l4",
+                  "description": "Ensure mr1l4 is in",
+                  "check": {
+                    "name": "check_mr1l4_xstate",
+                    "description": "Check if mr1l4 is inserted",
+                    "pv": "MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
+                    "value": "IN",
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_mr1l4_xstate",
+                    "description": "Move mr1l4 in",
+                    "pv": "MR1L4:HOMS:MMS:XUP:STATE:SET",
+                    "value": "IN",
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_mr1l4_xstate",
+                      "description": "Check if mr1l4 is inserted",
+                      "pv": "MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
+                      "value": "IN",
+                      "operator": "eq"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "point_mr1l4",
+                  "description": "Ensure mr1l4 is pointed towards MFX",
+                  "check": {
+                    "name": "check_mr1l4_pointing",
+                    "description": "Check if mr1l4 is pointing generally towards MFX",
+                    "memory": [
+                      false
+                    ],
+                    "pv": "MR1L4:HOMS:MMS:PITCH.RBV",
+                    "low_value": -549,
+                    "high_value": -539
+                  },
+                  "do": {
+                    "name": "act_mr1l4_pitch",
+                    "description": "Move mr1l4 back to the nominal pitch",
+                    "pv": "MR1L4:HOMS:MMS:PITCH.VAL",
+                    "value": -544,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "check_mr1l4_pointing",
+                      "description": "Check if mr1l4 is pointing generally towards MFX",
+                      "memory": [
+                        false
+                      ],
+                      "pv": "MR1L4:HOMS:MMS:PITCH.RBV",
+                      "low_value": -549,
+                      "high_value": -539
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "SelectorItem": {
+            "name": "ensure_dg1_cam_running",
+            "description": "Refresh acquisition if needed",
+            "memory": false,
+            "children": [
+              {
+                "ConditionItem": {
+                  "name": "Check_dg1_cam_running",
+                  "description": "Check if the camera is acquiring frames",
+                  "pv": "MFX:DG1:P6740:ArrayRate_RBV",
+                  "value": 1,
+                  "operator": "ge"
+                }
+              },
+              {
+                "SequenceItem": {
+                  "name": "seq_dg1_acq_cycle",
+                  "description": "Stop and then start the acquisition",
+                  "memory": false,
+                  "children": [
+                    {
+                      "SetPVActionItem": {
+                        "name": "act_dg1_no_acq",
+                        "description": "Stop acquiring",
+                        "pv": "MFX:DG1:P6740:Acquire",
+                        "value": 0,
+                        "loop_period_sec": 1.0,
+                        "termination_check": {
+                          "name": "",
+                          "description": "",
+                          "pv": "",
+                          "value": 1,
+                          "operator": "eq"
+                        }
+                      }
+                    },
+                    {
+                      "SetPVActionItem": {
+                        "name": "act_dg1_yes_acq",
+                        "description": "Start acquiring",
+                        "pv": "MFX:DG1:P6740:Acquire",
+                        "value": 1,
+                        "loop_period_sec": 1.0,
+                        "termination_check": {
+                          "name": "Check_dg1_cam_running",
+                          "description": "Check if the camera is acquiring frames",
+                          "pv": "MFX:DG1:P6740:ArrayRate_RBV",
+                          "value": 1,
+                          "operator": "ge"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/mfx_tree.json
+++ b/mfx_tree.json
@@ -37,25 +37,9 @@
               "value": 2,
               "loop_period_sec": 1.0,
               "termination_check": {
-                "name": "check_dg2_stp_in",
-                "description": "Check that dg2 stopper is at the closed switch but not at the open switch.",
-                "memory": false,
-                "children": [
-                  {
-                    "name": "check_dg2_stp_closed",
-                    "description": "Check that dg2 stopper is at closed switch.",
-                    "pv": "HFX:DG2:STP:01:CLOSE",
-                    "value": 1,
-                    "operator": "eq"
-                  },
-                  {
-                    "name": "check_dg2_stp_not_open",
-                    "description": "Check that dg2 stopper is not at open switch.",
-                    "pv": "HFX:DG2:STP:01:OPEN",
-                    "value": 0,
-                    "operator": "eq"
-                  }
-                ]
+                "name": "",
+                "description": "",
+                "copy_from": "previous check"
               }
             }
           }
@@ -84,11 +68,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl1_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:01",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -111,11 +93,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl2_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:02",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -138,11 +118,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl3_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:03",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -174,11 +152,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl1_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:01",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -201,11 +177,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl2_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:02",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -228,11 +202,9 @@
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_pfl3_out",
-                      "description": "Check if lens is removed",
-                      "pv": "MFX:LENS:DIA:03",
-                      "value": 0,
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -258,11 +230,9 @@
               "value": "YAG",
               "loop_period_sec": 1.0,
               "termination_check": {
-                "name": "check_dg1_yag_in",
-                "description": "Check if the dg1 yag is in",
-                "pv": "MFX:DG1:PIM",
-                "value": "YAG",
-                "operator": "eq"
+                "name": "",
+                "description": "",
+                "copy_from": "previous check"
               }
             }
           }
@@ -285,11 +255,9 @@
               "value": "YAG",
               "loop_period_sec": 1.0,
               "termination_check": {
-                "name": "check_dg2_yag_in",
-                "description": "Check if the dg2 yag is in",
-                "pv": "MFX:DG2:PIM",
-                "value": "YAG",
-                "operator": "eq"
+                "name": "",
+                "description": "",
+                "copy_from": "previous check"
               }
             }
           }
@@ -395,14 +363,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg1_x_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG1:JAWS:Actual_XWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -428,14 +391,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg1_y_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG1:JAWS:Actual_YWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -461,14 +419,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_us_x_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:US:Actual_XWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -494,14 +447,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_us_y_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:US:Actual_YWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -527,14 +475,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_ms_x_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:MS:Actual_XWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -560,14 +503,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_ms_y_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:MS:Actual_YWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -593,14 +531,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_ds_x_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:DS:Actual_XWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -626,14 +559,9 @@
                     "value": 2,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "dg2_ds_y_check",
-                      "description": "Check if slit width is close to 2mm",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MFX:DG2:JAWS:DS:Actual_YWIDTH",
-                      "low_value": 1.9,
-                      "high_value": 2.1
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -665,11 +593,9 @@
                     "value": "IN",
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_mr1l4_xstate",
-                      "description": "Check if mr1l4 is inserted",
-                      "pv": "MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
-                      "value": "IN",
-                      "operator": "eq"
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }
@@ -695,14 +621,9 @@
                     "value": -544,
                     "loop_period_sec": 1.0,
                     "termination_check": {
-                      "name": "check_mr1l4_pointing",
-                      "description": "Check if mr1l4 is pointing generally towards MFX",
-                      "memory": [
-                        false
-                      ],
-                      "pv": "MR1L4:HOMS:MMS:PITCH.RBV",
-                      "low_value": -549,
-                      "high_value": -539
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
                     }
                   }
                 }

--- a/mfx_tree.json
+++ b/mfx_tree.json
@@ -57,7 +57,7 @@
                   "check": {
                     "name": "check_pfl1_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:01",
+                    "pv": "MFX:LENS:DIA:01:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
@@ -82,7 +82,7 @@
                   "check": {
                     "name": "check_pfl2_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:02",
+                    "pv": "MFX:LENS:DIA:02:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
@@ -107,7 +107,7 @@
                   "check": {
                     "name": "check_pfl3_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:03",
+                    "pv": "MFX:LENS:DIA:03:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
@@ -136,19 +136,19 @@
             "children": [
               {
                 "CheckAndDoItem": {
-                  "name": "cad_pfl1_remove",
+                  "name": "cad_tfs1_remove",
                   "description": "Ensure lens is removed",
                   "check": {
-                    "name": "check_pfl1_out",
+                    "name": "check_tfs1_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:01",
+                    "pv": "MFX:LENS:TFS:01:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
                   "do": {
-                    "name": "act_pfl1_remove",
+                    "name": "act_tfs1_remove",
                     "description": "Remove lens",
-                    "pv": "MFX:LENS:DIA:01:REMOVE",
+                    "pv": "MFX:LENS:TFS:01:REMOVE",
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
@@ -161,19 +161,19 @@
               },
               {
                 "CheckAndDoItem": {
-                  "name": "cad_pfl2_remove",
+                  "name": "cad_tfs2_remove",
                   "description": "Ensure lens is removed",
                   "check": {
-                    "name": "check_pfl2_out",
+                    "name": "check_tfs2_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:02",
+                    "pv": "MFX:LENS:TFS:02:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
                   "do": {
-                    "name": "act_pfl2_remove",
+                    "name": "act_tfs2_remove",
                     "description": "Remove lens",
-                    "pv": "MFX:LENS:DIA:02:REMOVE",
+                    "pv": "MFX:LENS:TFS:02:REMOVE",
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {
@@ -186,19 +186,194 @@
               },
               {
                 "CheckAndDoItem": {
-                  "name": "cad_pfl3_remove",
+                  "name": "cad_tfs3_remove",
                   "description": "Ensure lens is removed",
                   "check": {
-                    "name": "check_pfl3_out",
+                    "name": "check_tfs3_out",
                     "description": "Check if lens is removed",
-                    "pv": "MFX:LENS:DIA:03",
+                    "pv": "MFX:LENS:TFS:03:STATE",
                     "value": 0,
                     "operator": "eq"
                   },
                   "do": {
-                    "name": "act_pfl3_remove",
+                    "name": "act_tfs3_remove",
                     "description": "Remove lens",
-                    "pv": "MFX:LENS:DIA:03:REMOVE",
+                    "pv": "MFX:LENS:TFS:03:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs4_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs4_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:04:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs4_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:04:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs5_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs5_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:05:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs5_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:05:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs6_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs6_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:06:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs6_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:06:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs7_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs7_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:07:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs7_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:07:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs8_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs8_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:08:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs8_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:08:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs9_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs9_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:09:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs9_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:09:REMOVE",
+                    "value": 1,
+                    "loop_period_sec": 1.0,
+                    "termination_check": {
+                      "name": "",
+                      "description": "",
+                      "copy_from": "previous check"
+                    }
+                  }
+                }
+              },
+              {
+                "CheckAndDoItem": {
+                  "name": "cad_tfs10_remove",
+                  "description": "Ensure lens is removed",
+                  "check": {
+                    "name": "check_tfs10_out",
+                    "description": "Check if lens is removed",
+                    "pv": "MFX:LENS:TFS:10:STATE",
+                    "value": 0,
+                    "operator": "eq"
+                  },
+                  "do": {
+                    "name": "act_tfs10_remove",
+                    "description": "Remove lens",
+                    "pv": "MFX:LENS:TFS:10:REMOVE",
                     "value": 1,
                     "loop_period_sec": 1.0,
                     "termination_check": {

--- a/mfx_tree.json
+++ b/mfx_tree.json
@@ -272,9 +272,7 @@
                 "RangeConditionItem": {
                   "name": "check_mfx_att_range",
                   "description": "Check if mfx_att is near 10% transmission",
-                  "memory": [
-                    false
-                  ],
+                  "memory": false,
                   "pv": "MFX:ATT:COM:R_CUR",
                   "low_value": 0.08,
                   "high_value": 0.12
@@ -321,9 +319,7 @@
                         "termination_check": {
                           "name": "check_mfx_att_range",
                           "description": "Check if mfx_att is near 10% transmission",
-                          "memory": [
-                            false
-                          ],
+                          "memory": false,
                           "pv": "MFX:ATT:COM:R_CUR",
                           "low_value": 0.08,
                           "high_value": 0.12
@@ -349,9 +345,7 @@
                   "check": {
                     "name": "dg1_x_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG1:JAWS:Actual_XWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -377,9 +371,7 @@
                   "check": {
                     "name": "dg1_y_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG1:JAWS:Actual_YWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -405,9 +397,7 @@
                   "check": {
                     "name": "dg2_us_x_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:US:Actual_XWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -433,9 +423,7 @@
                   "check": {
                     "name": "dg2_us_y_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:US:Actual_YWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -461,9 +449,7 @@
                   "check": {
                     "name": "dg2_ms_x_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:MS:Actual_XWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -489,9 +475,7 @@
                   "check": {
                     "name": "dg2_ms_y_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:MS:Actual_YWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -517,9 +501,7 @@
                   "check": {
                     "name": "dg2_ds_x_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:DS:Actual_XWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -545,9 +527,7 @@
                   "check": {
                     "name": "dg2_ds_y_check",
                     "description": "Check if slit width is close to 2mm",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MFX:DG2:JAWS:DS:Actual_YWIDTH",
                     "low_value": 1.9,
                     "high_value": 2.1
@@ -607,9 +587,7 @@
                   "check": {
                     "name": "check_mr1l4_pointing",
                     "description": "Check if mr1l4 is pointing generally towards MFX",
-                    "memory": [
-                      false
-                    ],
+                    "memory": false,
                     "pv": "MR1L4:HOMS:MMS:PITCH.RBV",
                     "low_value": -549,
                     "high_value": -539

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -104,7 +104,7 @@ for lens in range(10):
 transfocator_remove = SequenceItem(
     name="transfocator_remove",
     description="ensure all transfocator lenses are removed",
-    children=pfl_cads,
+    children=tfs_cads,
 )
 
 # Yags: insert

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -1,0 +1,151 @@
+from beams.tree_config import CheckAndDoItem, ConditionItem, SetPVActionItem, ConditionOperator, SequenceItem, SequenceConditionItem, RangeConditionItem
+
+# DG2 Stopper: remove
+check_dg2_stp_closed = ConditionItem(
+    name="check_dg2_stp_closed",
+    description="Check that dg2 stopper is at closed switch.",
+    pv="HFX:DG2:STP:01:CLOSE",
+    value=1,
+    operator=ConditionOperator.equal,
+)
+check_dg2_stp_not_open = ConditionItem(
+    name="check_dg2_stp_not_open",
+    description="Check that dg2 stopper is not at open switch.",
+    pv="HFX:DG2:STP:01:OPEN",
+    value=0,
+    operator=ConditionOperator.equal,
+)
+check_dg2_stp_in = SequenceConditionItem(
+    name="check_dg2_stp_in",
+    description="Check that dg2 stopper is at the closed switch but not at the open switch.",
+    children=[check_dg2_stp_closed, check_dg2_stp_not_open],
+)
+act_close_dg2_stp = SetPVActionItem(
+    name="act_close_dg2_stp",
+    description="Move dg2 stopper to block the beam.",
+    pv="HFX:DG2:STP:01:CMD",
+    value=2,
+)
+dg2_stopper = CheckAndDoItem(
+    name="dg2_stopper",
+    description="Ensure that dg2 is inserted before moving focusing optics.",
+    check=check_dg2_stp_in,
+    do=act_close_dg2_stp,
+)
+
+# Prefocusing Lens: remove
+pfl_cads = []
+for lens in range(3):
+    index = lens + 1
+    base_pv = f"MFX:LENS:DIA:0{index}"
+    state_pv = base_pv + ":STATE"
+    remove_pv = base_pv + ":REMOVE"
+    pfl_check = ConditionItem(
+        name=f"check_pfl{index}_out",
+        description="Check if lens is removed",
+        pv=base_pv,
+        value=0,
+        operator=ConditionOperator.equal,
+    )
+    pfl_remove = SetPVActionItem(
+        name=f"act_pfl{index}_remove",
+        description="Remove lens",
+        pv=remove_pv,
+        value=1,
+    )
+    pfl_cad = CheckAndDoItem(
+        name=f"cad_pfl{index}_remove",
+        description="Ensure lens is removed",
+        check=pfl_check,
+        do=pfl_remove,
+    )
+    pfl_cads.append(pfl_cad)
+
+prefocus_remove = SequenceItem(
+    name="prefocus_remove",
+    description="ensure all prefocusing lenses are removed",
+    children=pfl_cads,
+)
+
+# Transfocator: remove
+tfs_cads = []
+for lens in range(10):
+    index = lens + 1
+    base_pv = f"MFX:LENS:TFS:{index:02}"
+    state_pv = base_pv + ":STATE"
+    remove_pv = base_pv + ":REMOVE"
+    tfs_check = ConditionItem(
+        name=f"check_tfs{index}_out",
+        description="Check if lens is removed",
+        pv=base_pv,
+        value=0,
+        operator=ConditionOperator.equal,
+    )
+    tfs_remove = SetPVActionItem(
+        name=f"act_tfs{index}_remove",
+        description="Remove lens",
+        pv=remove_pv,
+        value=1,
+    )
+    tfs_cad = CheckAndDoItem(
+        name=f"cad_tfs{index}_remove",
+        description="Ensure lens is removed",
+        check=tfs_check,
+        do=tfs_remove,
+    )
+    tfs_cads.append(tfs_cad)
+
+transfocator_remove = SequenceItem(
+    name="transfocator_remove",
+    description="ensure all transfocator lenses are removed",
+    children=pfl_cads,
+)
+
+# Yags: insert
+check_dg1_yag_in = ConditionItem(
+    name="check_dg1_yag_in",
+    description="Check if the dg1 yag is in",
+    pv="MFX:DG1:PIM",
+    value="YAG",
+    operator=ConditionOperator.equal,
+)
+act_insert_dg1_yag = SetPVActionItem(
+    name="act_insert_dg1_yag",
+    description="Insert dg1 yag",
+    pv="MFX:DG1:PIM:GO",
+    value="YAG",
+)
+dg1_yag = CheckAndDoItem(
+    name="dg1_yag",
+    description="Ensure dg1_yag is inserted",
+    check=check_dg1_yag_in,
+    do=act_insert_dg1_yag,
+)
+check_dg2_yag_in = ConditionItem(
+    name="check_dg2_yag_in",
+    description="Check if the dg2 yag is in",
+    pv="MFX:DG2:PIM",
+    value="YAG",
+    operator=ConditionOperator.equal,
+)
+act_insert_dg2_yag = SetPVActionItem(
+    name="act_insert_dg2_yag",
+    description="Insert dg2 yag",
+    pv="MFX:DG2:PIM:GO",
+    value="YAG",
+)
+dg2_yag = CheckAndDoItem(
+    name="d2_yag",
+    description="Ensure dg2_yag is inserted",
+    check=check_dg2_yag_in,
+    do=act_insert_dg2_yag,
+)
+
+# Attenuator: drop to 10%
+check_mfx_att_range = RangeConditionItem(
+    name="check_mfx_att_range",
+    description="Check if mfx_att is near 10% transmission",
+    pv="MFX:ATT:COM:R_CUR",
+    low_value=0.08,
+    high_value=0.12,
+)

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -1,4 +1,7 @@
-from beams.tree_config import CheckAndDoItem, ConditionItem, SetPVActionItem, ConditionOperator, SequenceItem, SequenceConditionItem, RangeConditionItem, SelectorItem
+from beams.tree_config import (CheckAndDoItem, ConditionItem,
+                               ConditionOperator, RangeConditionItem,
+                               SelectorItem, SequenceConditionItem,
+                               SequenceItem, SetPVActionItem)
 
 # DG2 Stopper: remove
 check_dg2_stp_closed = ConditionItem(

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -1,4 +1,4 @@
-from beams.tree_config import CheckAndDoItem, ConditionItem, SetPVActionItem, ConditionOperator, SequenceItem, SequenceConditionItem, RangeConditionItem
+from beams.tree_config import CheckAndDoItem, ConditionItem, SetPVActionItem, ConditionOperator, SequenceItem, SequenceConditionItem, RangeConditionItem, SelectorItem
 
 # DG2 Stopper: remove
 check_dg2_stp_closed = ConditionItem(
@@ -149,3 +149,150 @@ check_mfx_att_range = RangeConditionItem(
     low_value=0.08,
     high_value=0.12,
 )
+check_calc_ready = ConditionItem(
+    name="check_calc_ready",
+    description="Wait for previous or current calc to be done",
+    pv="MFX:ATT:COM:CALCP",
+    value=0,
+)
+act_prepare_transmission = SetPVActionItem(
+    name="act_prepare_transmission",
+    description="Set the transmission that will be applied",
+    pv="MFX:ATT:COM:R_DES",
+    value=0.1,
+)
+act_apply_transmission = SetPVActionItem(
+    name="act_apply_transmission",
+    description="Move the attenuator to the lesser of the two att options",
+    pv="MFX:ATT:COM:GO",
+    value=3,
+    termination_check=check_mfx_att_range,
+)
+seq_set_mfx_att = SequenceItem(
+    name="seq_set_mfx_att",
+    description="Set the mfx att to 10% transmission",
+    children=[check_calc_ready, act_prepare_transmission, act_apply_transmission],
+)
+mfx_att = SelectorItem(
+    name="mfx_att",
+    description="Ensure mfx att is near 10% transmission for alignment",
+    children=[check_mfx_att_range, seq_set_mfx_att],
+)
+
+# Slits: all to 2mm
+slit_cads = []
+for slit_name, pv_ext in (
+    ("dg1", "DG1:JAWS"),
+    ("dg2_us", "DG2:JAWS:US"),
+    ("dg2_ms", "DG2:JAWS:MS"),
+    ("dg2_ds", "DG2:JAWS:DS"),
+):
+    base_pv = f"MFX:{pv_ext}:"
+    for axis in ("X", "Y"):
+        axis_name = f"{slit_name}_{axis.lower()}"
+        slit_check = RangeConditionItem(
+            name=f"{axis_name}_check",
+            description="Check if slit width is close to 2mm",
+            pv=f"{base_pv}Actual_{axis}WIDTH",
+            low_value=1.9,
+            high_value=2.1,
+        )
+        slit_move = SetPVActionItem(
+            name=f"{axis_name}_move",
+            description="Move slit width to 2mm",
+            pv=f"{base_pv}{axis}WID_REQ",
+            value=2,
+        )
+        slcad = CheckAndDoItem(
+            name=f"{axis_name}_check_and_do",
+            description="Ensure slit width is close to 2mm",
+            check=slit_check,
+            do=slit_move,
+        )
+        slit_cads.append(slcad)
+slits_to_2mm = SequenceItem(
+    name="slits_to_2mm",
+    description="Ensure all slit widths are close to 2mm",
+    children=slit_cads,
+)
+
+# MR1L4 MFX/MEC mirror
+check_mr1l4_xstate = ConditionItem(
+    name="check_mr1l4_xstate",
+    description="Check if mr1l4 is inserted",
+    pv="MR1L4:HOMS:MMS:XUP:STATE:GET_RBV",
+    value="IN",
+    operator=ConditionOperator.equal,
+)
+act_mr1l4_xstate = SetPVActionItem(
+    name="act_mr1l4_xstate",
+    description="Move mr1l4 in",
+    pv="MR1L4:HOMS:MMS:XUP:STATE:SET",
+    value="IN",
+)
+insert_mr1l4 = CheckAndDoItem(
+    name="insert_mr1l4",
+    description="Ensure mr1l4 is in",
+    check=check_mr1l4_xstate,
+    do=act_mr1l4_xstate,
+)
+mr1l4_nominal = -544
+check_mr1l4_pointing = RangeConditionItem(
+    name="check_mr1l4_pointing",
+    description="Check if mr1l4 is pointing generally towards MFX",
+    pv="MR1L4:HOMS:MMS:PITCH.RBV",
+    low_value=mr1l4_nominal-5,
+    high_value=mr1l4_nominal+5,
+)
+act_mr1l4_pitch = SetPVActionItem(
+    name="act_mr1l4_pitch",
+    description="Move mr1l4 back to the nominal pitch",
+    pv="MR1L4:HOMS:MMS:PITCH.VAL",
+    value=mr1l4_nominal,
+)
+point_mr1l4 = CheckAndDoItem(
+    name="point_mr1l4",
+    description="Ensure mr1l4 is pointed towards MFX",
+    check=check_mr1l4_pointing,
+    do=act_mr1l4_pitch,
+)
+prepare_mr1l4 = SequenceItem(
+    name="prepare_mr1l4",
+    description="Get mr1l4 ready for MFX beam",
+    children=[insert_mr1l4, point_mr1l4],
+)
+
+# Set up the DG1 camera
+check_dg1_cam_running = ConditionItem(
+    name="Check_dg1_cam_running",
+    description="Check if the camera is acquiring frames",
+    pv="MFX:DG1:P6740:ArrayRate_RBV",
+    value=1,
+    operator=ConditionOperator.greater_equal,
+)
+# If the cam isn't running, it either needs to be turned on, or off and back on
+# Simplest is to put the "off" and then the "on" in series without checking.
+act_dg1_no_acq = SetPVActionItem(
+    name="act_dg1_no_acq",
+    description="Stop acquiring",
+    pv="MFX:DG1:P6740:Acquire",
+    value=0,
+)
+act_dg1_yes_acq = SetPVActionItem(
+    name="act_dg1_yes_acq",
+    description="Start acquiring",
+    pv="MFX:DG1:P6740:Acquire",
+    value=1,
+    termination_check=check_dg1_cam_running,
+)
+seq_dg1_acq_cycle = SequenceItem(
+    name="seq_dg1_acq_cycle",
+    description="Stop and then start the acquisition",
+    children=[act_dg1_no_acq, act_dg1_yes_acq],
+)
+ensure_dg1_cam_running = SelectorItem(
+    name="ensure_dg1_cam_running",
+    description="Refresh acquisition if needed",
+    children=[check_dg1_cam_running, seq_dg1_acq_cycle],
+)
+# Skip stats for now

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -49,7 +49,7 @@ for lens in range(3):
     pfl_check = ConditionItem(
         name=f"check_pfl{index}_out",
         description="Check if lens is removed",
-        pv=base_pv,
+        pv=state_pv,
         value=0,
         operator=ConditionOperator.equal,
     )
@@ -83,7 +83,7 @@ for lens in range(10):
     tfs_check = ConditionItem(
         name=f"check_tfs{index}_out",
         description="Check if lens is removed",
-        pv=base_pv,
+        pv=state_pv,
         value=0,
         operator=ConditionOperator.equal,
     )

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -299,3 +299,21 @@ ensure_dg1_cam_running = SelectorItem(
     children=[check_dg1_cam_running, seq_dg1_acq_cycle],
 )
 # Skip stats for now
+
+
+# Full subtree top-level sequence
+dg1_prep = SequenceItem(
+    name="dg1_prep",
+    description="Prepare MFX for alignment to DG1",
+    children=[
+        dg2_stopper,
+        prefocus_remove,
+        transfocator_remove,
+        dg1_yag,
+        dg2_yag,
+        mfx_att,
+        slits_to_2mm,
+        prepare_mr1l4,
+        ensure_dg1_cam_running,
+    ],
+)

--- a/mfx_tree.py
+++ b/mfx_tree.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 from beams.tree_config import (CheckAndDoItem, ConditionItem,
                                ConditionOperator, RangeConditionItem,
                                SelectorItem, SequenceConditionItem,
-                               SequenceItem, SetPVActionItem)
+                               SequenceItem, SetPVActionItem,
+                               save_tree_to_path)
 
 # DG2 Stopper: remove
 check_dg2_stp_closed = ConditionItem(
@@ -317,3 +320,8 @@ dg1_prep = SequenceItem(
         ensure_dg1_cam_running,
     ],
 )
+
+
+def update_mfx_json():
+    path = Path(__file__).parent / "mfx_tree.json"
+    save_tree_to_path(path=path, root=dg1_prep)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 apischema
 grpcio-tools
+jinja2
 py-trees
 pyepics
 pyyaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This is a draft PR intended for discussion rather than for merging.

As per #21 and https://jira.slac.stanford.edu/browse/BEAMS-6, this includes a realistic tree example that I used to get a feel for how much the existing structures were usable in a mid-sized close-to-real-world example.

This tree is intended to be part of a larger tree that would help MFX scientists set up their beamline. It would do the menial tasks like set slits to known values, put various devices in or out, and generally get the beamline ready to manually center the beam on the DG1 yag.

In the process, I made some prospective additions and changes to the tree_config submodule. These are all up for discussion and could be kept or discarded as appropriate: for example, perhaps it is more useful to adjust the existing resources rather than add these new resources?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to try this out on a sizeable real system and this gets us closer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not at all, I was planning to make a caproto IOC or do some blackboard monkeypatching to play around with the logic in debug.

If any of the additions to tree_config are kept I can add the respective test cases.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only here and in the jira ticket.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
