### PR TITLE
ENH: add test ioc generator from #54

### DIFF
--- a/beams/bin/gen_test_ioc.py
+++ b/beams/bin/gen_test_ioc.py
@@ -1,0 +1,36 @@
+"""
+Generate a test caproto IOC containing all the PVs from a tree set to 0 with no special logic.
+
+Intended usage is something like:
+beams gen_test_ioc my_tree.json > outfile.py
+
+Then, edit outfile.py to set useful starting values and add logic if needed.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        "filepath",
+        type=str,
+        help="Behavior Tree configuration filepath"
+    )
+
+
+def main(*args, **kwargs):
+    from beams.bin.gen_test_ioc_main import main
+    main(*args, **kwargs)

--- a/beams/bin/gen_test_ioc_main.py
+++ b/beams/bin/gen_test_ioc_main.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Iterator
+
+import jinja2
+
+
+def main(
+    filepath: str,
+):
+    with open(filepath, "r") as fd:
+        deser = json.load(fd)
+    all_pvnames = sorted(list(set(pv for pv in walk_dict_pvs(deser))))
+
+    if not all_pvnames:
+        raise RuntimeError(f"Found zero PVs in {filepath}")
+
+    jinja_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(Path(__file__).parent),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = jinja_env.get_template("test_ioc.py.j2")
+    rendered = template.render(all_pvnames=all_pvnames)
+    print(rendered)
+
+
+def walk_dict_pvs(tree_dict: dict) -> Iterator[str]:
+    for key, value in tree_dict.items():
+        if key == "pv" and value:
+            yield value
+        elif isinstance(value, dict):
+            yield from walk_dict_pvs(value)
+        elif isinstance(value, list):
+            for subdict in value:
+                yield from walk_dict_pvs(subdict)

--- a/beams/bin/gen_test_ioc_main.py
+++ b/beams/bin/gen_test_ioc_main.py
@@ -28,9 +28,11 @@ def main(
 def walk_dict_pvs(tree_dict: dict) -> Iterator[str]:
     for key, value in tree_dict.items():
         if key == "pv" and value:
-            yield value
+            yield str(value)
         elif isinstance(value, dict):
             yield from walk_dict_pvs(value)
         elif isinstance(value, list):
-            for subdict in value:
-                yield from walk_dict_pvs(subdict)
+            for subitem in value:
+                # Don't try to handle nested lists etc.
+                if isinstance(subitem, dict):
+                    yield from walk_dict_pvs(subitem)

--- a/beams/bin/main.py
+++ b/beams/bin/main.py
@@ -14,6 +14,7 @@ DESCRIPTION = __doc__
 
 COMMAND_TO_MODULE = {
     "run": "run",
+    "gen_test_ioc": "gen_test_ioc",
 }
 
 

--- a/beams/bin/test_ioc.py.j2
+++ b/beams/bin/test_ioc.py.j2
@@ -1,0 +1,27 @@
+from textwrap import dedent
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class BTSimIOC(PVGroup):
+    """
+    An IOC to replicate the PVs used by your behavior tree.
+    """
+{% for pvname in all_pvnames %}
+    {{ pvname.lower().replace(":","_").replace(".","_") }} = pvproperty(
+        value=0,
+        name="{{ pvname }}",
+        doc="Fake {{ pvname }}",
+    )
+{% endfor %}
+
+
+if __name__ == '__main__':
+    # Default is 5064, switch to 5066 to avoid conflict with prod
+    # Set this in terminal before you run your tree too to connect to this sim
+    os.environ["EPICS_CA_SERVER_PORT"] = "5066"
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='',
+        desc=dedent(BTSimIOC.__doc__))
+    ioc = BTSimIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/docs/source/upcoming_release_notes/57-enh_test_ioc_gen.rst
+++ b/docs/source/upcoming_release_notes/57-enh_test_ioc_gen.rst
@@ -1,0 +1,28 @@
+57 enh_test_ioc_gen
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add subcommand "beams gen_test_ioc", which can be used to generate a
+  logic-free caproto IOC that mirrors a serialized json behavior tree's
+  PVs.
+  The expected usage is "beams gen_test_ioc my_bt.json > my_server.py".
+  The resulting server file should be hand-edited to have the correct
+  types and starting values. The server by default runs on non-standard
+  port 5066 so that it can be used to test a real behavior tree as-is.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 apischema
 grpcio-tools
+jinja2
 py-trees
 pyepics
 pyyaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a subcommand that takes a tree .json file, scrapes it for "pv" fields, and generates a boilerplate caproto ioc (some configuration required) for use in testing.

Split off from #54 

Future to-do options:

- [ ] Get current values and record types from real PVs and make the IOC automatically more authentic/true to life
- [ ] Generate and run a basic screen for controlling the test PVs
- [ ] Create standalone tool for this in other contexts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #54 I had a tree with too many PVs to fill accurately by hand, so I created this helper.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only
Added a unit test that generates a caproto ioc and imports to check it has the right PV in it.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Later, in pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
