### PR TITLE
ENH: include save_tree_to_path from #54

### DIFF
--- a/beams/tests/test_tree_generator.py
+++ b/beams/tests/test_tree_generator.py
@@ -6,7 +6,8 @@ from caproto.tests.conftest import run_example_ioc
 from epics import caget
 
 from beams.behavior_tree.CheckAndDo import CheckAndDo
-from beams.tree_config import get_tree_from_path
+from beams.tree_config import (CheckAndDoItem, get_tree_from_path,
+                               save_tree_item_to_path)
 
 
 def test_tree_obj_ser():
@@ -66,3 +67,12 @@ def test_father_tree_execution(request):
     check_insert = caget("RET:INSERT")
 
     assert check_insert == 1
+
+
+def test_save_tree_item_round_trip(tmp_path: Path):
+    filepath = tmp_path / "temp_egg.json"
+    item = CheckAndDoItem(name="test_save_tree_item_round_trip")
+    save_tree_item_to_path(path=filepath, root=item)
+    loaded_tree = get_tree_from_path(path=filepath)
+    assert isinstance(loaded_tree.root, CheckAndDo)
+    assert loaded_tree.root.name == item.name

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -27,7 +27,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_tree_from_path(path: Path) -> py_trees.trees.BehaviourTree:
-    """Deserialize a json file, return the tree it specifies"""
+    """
+    Deserialize a json file, return the tree it specifies.
+
+    This can be used internally to conveniently and consistently load
+    serialized json files as ready-to-run behavior trees.
+    """
     with open(path, "r") as fd:
         deser = json.load(fd)
         tree_item = deserialize(BehaviorTreeItem, deser)
@@ -35,8 +40,17 @@ def get_tree_from_path(path: Path) -> py_trees.trees.BehaviourTree:
     return tree_item.get_tree()
 
 
-def save_tree_to_path(path: Union[Path, str], root: BaseItem):
-    """Serialize a behavior tree node to a json file."""
+def save_tree_item_to_path(path: Union[Path, str], root: BaseItem):
+    """
+    Serialize a behavior tree item to a json file.
+
+    This can be used to generate serialized trees from python scripts.
+    The user needs to create various interwoven tree items, pick the
+    correct item to be the root node, and then use this function to
+    save the serialized file.
+
+    These files are ready to be consumed by get_tree_from_path.
+    """
     ser = serialize(BehaviorTreeItem(root=root))
 
     with open(path, "w") as fd:

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
 import py_trees
-from apischema import deserialize
+from apischema import deserialize, serialize
 from epics import caget, caput
 from py_trees.behaviour import Behaviour
 from py_trees.behaviours import (CheckBlackboardVariableValue,
@@ -33,6 +33,15 @@ def get_tree_from_path(path: Path) -> py_trees.trees.BehaviourTree:
         tree_item = deserialize(BehaviorTreeItem, deser)
 
     return tree_item.get_tree()
+
+
+def save_tree_to_path(path: Union[Path, str], root: BaseItem):
+    """Serialize a behavior tree node to a json file."""
+    ser = serialize(BehaviorTreeItem(root=root))
+
+    with open(path, "w") as fd:
+        json.dump(ser, fd, indent=2)
+        fd.write("\n")
 
 
 @dataclass

--- a/docs/source/upcoming_release_notes/58-enh_add_serialize_helper.rst
+++ b/docs/source/upcoming_release_notes/58-enh_add_serialize_helper.rst
@@ -1,0 +1,23 @@
+58 enh_add_serialize_helper
+###########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add ``save_tree_item_to_path``, a helper function for serializing user-made
+  behavior trees into the format usable by ``get_tree_from_path``.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Improve docstring on ``get_tree_from_path``.
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Include `save_tree_item_to_path`, a companion to `get_tree_from_path` that takes a fully constructed behavior tree item and saves it to a json file. It is intended that any tree serialized this way will be usable by `get_tree_from_path`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had to google `apischema`'s API to serialize my behavior tree and I thought I shouldn't have to do that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively and added a unit test.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I added a pre-release documentation entry.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
