### PR TITLE
ENH: add RangeConditionItem from #54

### DIFF
--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -156,6 +156,46 @@ class ConditionItem(BaseItem):
 
 
 @dataclass
+class RangeConditionItem(BaseItem):
+    """
+    Shorthand for a sequence of two condition items, establishing a range.
+    """
+    memory: bool = False
+    pv: str = ""
+    low_value: Any = 0
+    high_value: Any = 1,
+
+    def _generate_subconfig(self) -> SequenceConditionItem:
+        low = ConditionItem(
+            name=f"{self.name}_lower_bound",
+            description=f"Lower bound for {self.name} check",
+            pv=self.pv,
+            value=self.low_value,
+            operator=ConditionOperator.greater_equal,
+        )
+        high = ConditionItem(
+            name=f"{self.name}_upper_bound",
+            description=f"Upper bound for {self.name} check",
+            pv=self.pv,
+            value=self.high_value,
+            operator=ConditionOperator.less_equal,
+        )
+        range = SequenceConditionItem(
+            name=self.name,
+            description=self.description,
+            memory=self.memory,
+            children=[low, high],
+        )
+        return range
+
+    def get_tree(self) -> Sequence:
+        return self._generate_subconfig().get_tree()
+
+    def get_condition_function(self) -> Callable[[], bool]:
+        return self._generate_subconfig().get_condition_function()
+
+
+@dataclass
 class SetPVActionItem(BaseItem):
     pv: str = ""
     value: Any = 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This adds the `RangeConditionItem` from #54 as-is

It doesn't work without the adjustments from #59 
It needs to be revised in general because we weren't happy with it

We should do one of the following:
- Expand the operator-based checks in place
- Refactor the operator-based checks to use explicit function references

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's annoying to add three nodes for such a simple check, so this idiom generates the three nodes for me.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Needs unit tests following rework

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Later in pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
