### PR TITLE
ENH: default handling for check_and_do with no termination check

### DIFF
--- a/beams/tests/artifacts/egg_generator.py
+++ b/beams/tests/artifacts/egg_generator.py
@@ -20,9 +20,7 @@ def create_egg_1(write: bool = False):
                           operator=ConditionOperator.greater_equal)
     do = IncPVActionItem(
         name='self_test_do', loop_period_sec=0.01, pv="PERC:COMP",
-        increment=10, termination_check=ConditionItem(
-            pv="PERC:COMP", value=100, operator=ConditionOperator.greater_equal
-        )
+        increment=10
     )
     cnd_test = CheckAndDoItem(name='self_test', check=check, do=do)
 
@@ -45,23 +43,17 @@ def create_egg_2(write: bool = False):
     check_item_1 = ConditionItem(name='ret_find_check', pv='RET:FOUND', value=1,
                                  operator=ConditionOperator.greater_equal)
     do_item_1 = SetPVActionItem(
-        name='ret_find_do', pv='RET:FOUND', value=1, loop_period_sec=0.01,
-        termination_check=ConditionItem(
-            pv="RET:FOUND", value=1, operator=ConditionOperator.greater_equal
-        )
+        name='ret_find_do', pv='RET:FOUND', value=1, loop_period_sec=0.01
     )
     cnd_1 = CheckAndDoItem(name='ret_find', check=check_item_1, do=do_item_1)
 
     seq.children.append(cnd_1)
 
     # CheckAndDo2
-    check2 = ConditionItem(pv="RET:INSERT", value=1,
+    check2 = ConditionItem(name="ret_insert_check", pv="RET:INSERT", value=1,
                            operator=ConditionOperator.greater_equal)
     do2 = SetPVActionItem(
-        pv="RET:INSERT", value=1,
-        termination_check=ConditionItem(
-            pv='RET:INSERT', value=1, operator=ConditionOperator.greater_equal
-        )
+        name="ret_insert_do", pv="RET:INSERT", value=1,
     )
     cnd_2 = CheckAndDoItem(name='ret_insert', check=check2, do=do2)
     seq.children.append(cnd_2)
@@ -130,12 +122,6 @@ def create_im2l0_test(write: bool = False):
         loop_period_sec=0.01,
         pv="IM2L0:XTES:MMS:STATE:GET_RBV",
         value="OUT",
-        termination_check=ConditionItem(
-            name="check_reticule_state",
-            pv="IM2L0:XTES:MMS:STATE:GET_RBV",
-            value="OUT",
-            operator=ConditionOperator.equal
-        )
     )
     cnd1 = CheckAndDoItem(name="reticle_state_out", check=check, do=do)
 
@@ -150,12 +136,6 @@ def create_im2l0_test(write: bool = False):
         loop_period_sec=0.01,
         pv="IM2L0:XTES:CLZ.RBV",
         value=25,
-        termination_check=ConditionItem(
-            name="check_zoom_motor",
-            pv="IM2L0:XTES:CLZ.RBV",
-            value=25,
-            operator=ConditionOperator.equal
-        )
     )
     cnd2 = CheckAndDoItem(name="zoom_motor", check=check2, do=do2)
 
@@ -170,12 +150,6 @@ def create_im2l0_test(write: bool = False):
         loop_period_sec=0.01,
         pv="IM2L0:XTES:CLF.RBV",
         value=50,
-        termination_check=ConditionItem(
-            name="check_focus_motor",
-            pv="IM2L0:XTES:CLF.RBV",
-            value=50,
-            operator=ConditionOperator.equal
-        )
     )
     cnd3 = CheckAndDoItem(name="focus_motor", check=check3, do=do3)
 

--- a/beams/tests/artifacts/eggs.json
+++ b/beams/tests/artifacts/eggs.json
@@ -19,12 +19,9 @@
         "increment": 10,
         "loop_period_sec": 0.01,
         "termination_check": {
-          "ConditionItem": {
-            "name": "",
-            "description": "",
-            "pv": "PERC:COMP",
-            "value": 100,
-            "operator": "ge"
+          "UseCheckConditionItem": {
+            "name": "self_test_do_termination_check",
+            "description": "Use parent's check node: self_test_check"
           }
         }
       }

--- a/beams/tests/artifacts/eggs2.json
+++ b/beams/tests/artifacts/eggs2.json
@@ -25,12 +25,9 @@
               "value": 1,
               "loop_period_sec": 0.01,
               "termination_check": {
-                "ConditionItem": {
-                  "name": "",
-                  "description": "",
-                  "pv": "RET:FOUND",
-                  "value": 1,
-                  "operator": "ge"
+                "UseCheckConditionItem": {
+                  "name": "ret_find_do_termination_check",
+                  "description": "Use parent's check node: ret_find_check"
                 }
               }
             }
@@ -42,7 +39,7 @@
             "description": "",
             "check": {
               "ConditionItem": {
-                "name": "",
+                "name": "ret_insert_check",
                 "description": "",
                 "pv": "RET:INSERT",
                 "value": 1,
@@ -50,18 +47,15 @@
               }
             },
             "do": {
-              "name": "",
+              "name": "ret_insert_do",
               "description": "",
               "pv": "RET:INSERT",
               "value": 1,
               "loop_period_sec": 1.0,
               "termination_check": {
-                "ConditionItem": {
-                  "name": "",
-                  "description": "",
-                  "pv": "RET:INSERT",
-                  "value": 1,
-                  "operator": "ge"
+                "UseCheckConditionItem": {
+                  "name": "ret_insert_do_termination_check",
+                  "description": "Use parent's check node: ret_insert_check"
                 }
               }
             }

--- a/beams/tests/artifacts/im2l0_test.json
+++ b/beams/tests/artifacts/im2l0_test.json
@@ -25,12 +25,9 @@
               "value": "OUT",
               "loop_period_sec": 0.01,
               "termination_check": {
-                "ConditionItem": {
-                  "name": "check_reticule_state",
-                  "description": "",
-                  "pv": "IM2L0:XTES:MMS:STATE:GET_RBV",
-                  "value": "OUT",
-                  "operator": "eq"
+                "UseCheckConditionItem": {
+                  "name": "set_reticule_state_to_out_termination_check",
+                  "description": "Use parent's check node: check_reticule_state"
                 }
               }
             }
@@ -56,12 +53,9 @@
               "value": 25,
               "loop_period_sec": 0.01,
               "termination_check": {
-                "ConditionItem": {
-                  "name": "check_zoom_motor",
-                  "description": "",
-                  "pv": "IM2L0:XTES:CLZ.RBV",
-                  "value": 25,
-                  "operator": "eq"
+                "UseCheckConditionItem": {
+                  "name": "set_zoom_motor_termination_check",
+                  "description": "Use parent's check node: check_zoom_motor"
                 }
               }
             }
@@ -87,12 +81,9 @@
               "value": 50,
               "loop_period_sec": 0.01,
               "termination_check": {
-                "ConditionItem": {
-                  "name": "check_focus_motor",
-                  "description": "",
-                  "pv": "IM2L0:XTES:CLF.RBV",
-                  "value": 50,
-                  "operator": "eq"
+                "UseCheckConditionItem": {
+                  "name": "set_focus_motor_termination_check",
+                  "description": "Use parent's check node: check_focus_motor"
                 }
               }
             }

--- a/beams/tests/artifacts/im2l0_test.json
+++ b/beams/tests/artifacts/im2l0_test.json
@@ -87,7 +87,7 @@
               "value": 50,
               "loop_period_sec": 0.01,
               "termination_check": {
-                  "ConditionItem": {
+                "ConditionItem": {
                   "name": "check_focus_motor",
                   "description": "",
                   "pv": "IM2L0:XTES:CLF.RBV",

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import operator
-import time
 from copy import copy
 from dataclasses import dataclass, field, fields
 from enum import Enum
@@ -320,9 +319,12 @@ class CheckAndDoItem(BaseItem):
 
     def __post_init__(self):
         # Clearly indicate the intent for serialization
-        # If no termination check, use the check's check
-        if not self.do.termination_check.name:
-            self.do.termination_check = UseCheckConditionItem()
+        # If termination check is the default default, create the dummy item instead
+        if self.do.termination_check == CheckAndDoItem().do.termination_check:
+            self.do.termination_check = UseCheckConditionItem(
+                name=f"{self.do.name}_termination_check",
+                description=f"Use parent's check node: {self.check.name}"
+            )
 
     def get_tree(self) -> CheckAndDo:
         if isinstance(self.do.termination_check, UseCheckConditionItem):
@@ -340,11 +342,13 @@ class CheckAndDoItem(BaseItem):
 
 
 @dataclass
-class UseCheckConditionItem(BaseItem):
+class UseCheckConditionItem(BaseConditionItem):
     """
     Dummy item: indicates that check and do should use "check" as do's termination check.
+
+    If used in any other context the tree will not be constructable.
     """
-    copy_from: str = "previous check"
+    ...
 
 
 # py_trees.behaviours Behaviour items

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -320,7 +320,7 @@ class CheckAndDoItem(BaseItem):
     def __post_init__(self):
         # Clearly indicate the intent for serialization
         # If termination check is the default default, create the dummy item instead
-        if self.do.termination_check == SetPVActionItem().termination_check:
+        if self.do.termination_check == ConditionItem():
             self.do.termination_check = UseCheckConditionItem(
                 name=f"{self.do.name}_termination_check",
                 description=f"Use parent's check node: {self.check.name}"

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -320,7 +320,7 @@ class CheckAndDoItem(BaseItem):
     def __post_init__(self):
         # Clearly indicate the intent for serialization
         # If termination check is the default default, create the dummy item instead
-        if self.do.termination_check == SetPVActionItem():
+        if self.do.termination_check == SetPVActionItem().termination_check:
             self.do.termination_check = UseCheckConditionItem(
                 name=f"{self.do.name}_termination_check",
                 description=f"Use parent's check node: {self.check.name}"

--- a/beams/tree_config.py
+++ b/beams/tree_config.py
@@ -320,7 +320,7 @@ class CheckAndDoItem(BaseItem):
     def __post_init__(self):
         # Clearly indicate the intent for serialization
         # If termination check is the default default, create the dummy item instead
-        if self.do.termination_check == CheckAndDoItem().do.termination_check:
+        if self.do.termination_check == SetPVActionItem():
             self.do.termination_check = UseCheckConditionItem(
                 name=f"{self.do.name}_termination_check",
                 description=f"Use parent's check node: {self.check.name}"

--- a/docs/source/upcoming_release_notes/61-enh_check_and_do_more.rst
+++ b/docs/source/upcoming_release_notes/61-enh_check_and_do_more.rst
@@ -1,0 +1,24 @@
+61 enh_check_and_do_more
+########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Allow an action item's termination_check to be omitted if it will be used as the "do" in a ``CheckAndDoItem``.
+  In these cases, the "check" node will be used as the termination check and a placeholder ``UseCheckConditionItem``
+  will be included in the serialized data structure.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Modify the egg generator to use the ``UseCheckConditionItem`` and regenerate the test artifacts.
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Create a dummy check item called `UseCheckConditionItem`
- When a `CheckAndDoItem` is created with a `do` entry that has no `termination_check`, replace the termination check with `UseCheckConditionItem`
- When a `CheckAndDoItem` is expanded to a tree, re-use the `check` item as the `do`'s `termination_check`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- I shouldn't need to specify this, it's redundant
- Without this PR, the `CheckAndDoItem` serializes with two copies of the same check item, but with this PR the `termination_check` serializes to a conceptual pointer to the check item instead. This makes it easier to edit the trees in place without having to redo changes in multiple dataclasses.
- Without this PR, the default handling for `termination_check` will always fail (compare blank PV to static number)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test
Regenerated the eggs to use it
No old tests broke

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll need to make pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
