### PR TITLE
TST: clean up pytest spam, warnings

### DIFF
--- a/beams/behavior_tree/ActionNode.py
+++ b/beams/behavior_tree/ActionNode.py
@@ -37,6 +37,7 @@ class ActionNode(py_trees.behaviour.Behaviour):
             comp_cond=completion_condition,
             stop_func=None
         )  # TODO: some standard notion of stop function could be valuable
+        self.is_set_up = False
         logger.debug("%s.__init__()" % (self.__class__.__name__))
 
     def setup(self, **kwargs: int) -> None:
@@ -51,8 +52,14 @@ class ActionNode(py_trees.behaviour.Behaviour):
         # Having this in setup means the workthread should always be running.
         self.worker.start_work()
         atexit.register(
-            self.worker.stop_work
+            self.shutdown
         )  # TODO(josh): make sure this cleans up resources when it dies
+        self.is_set_up = True
+
+    def shutdown(self) -> None:
+        if self.is_set_up:
+            self.worker.stop_work()
+            self.is_set_up = False
 
     def initialise(self) -> None:
         """

--- a/beams/tests/test_check_and_do.py
+++ b/beams/tests/test_check_and_do.py
@@ -12,7 +12,7 @@ from beams.behavior_tree.ConditionNode import ConditionNode
 logger = logging.getLogger(__name__)
 
 
-def test_check_and_do():
+def test_check_and_do(bt_cleaner):
     percentage_complete = Value("i", 0)
 
     @wrapped_action_work(loop_period_sec=0.001)
@@ -38,6 +38,7 @@ def test_check_and_do():
     check = ConditionNode("check", check_fn, percentage_complete)
 
     candd = CheckAndDo("yuhh", check, action)
+    bt_cleaner.register(candd)
     candd.setup_with_descendants()
 
     while (

--- a/beams/tests/test_leaf_node.py
+++ b/beams/tests/test_leaf_node.py
@@ -11,7 +11,7 @@ from beams.behavior_tree.ConditionNode import ConditionNode
 logger = logging.getLogger(__name__)
 
 
-def test_action_node():
+def test_action_node(bt_cleaner):
     # For test
     percentage_complete = Value("i", 0)
 
@@ -28,6 +28,7 @@ def test_action_node():
 
     action = ActionNode(name="action", work_func=work_func,
                         completion_condition=comp_cond)
+    bt_cleaner.register(action)
     action.setup()
     for _ in range(20):
         time.sleep(0.01)
@@ -35,7 +36,7 @@ def test_action_node():
     assert percentage_complete.value == 100
 
 
-def test_action_node_timeout():
+def test_action_node_timeout(bt_cleaner):
     # For test
     percentage_complete = Value("i", 0)
 
@@ -52,6 +53,7 @@ def test_action_node_timeout():
 
     action = ActionNode(name="action", work_func=work_func,
                         completion_condition=comp_cond)
+    bt_cleaner.register(action)
     action.setup()
 
     while action.status not in (
@@ -64,11 +66,12 @@ def test_action_node_timeout():
     assert percentage_complete.value != 100
 
 
-def test_condition_node():
+def test_condition_node(bt_cleaner):
     def condition_fn():
         return True
 
     con = ConditionNode("con", condition_fn)
+    bt_cleaner.register(con)
     con.setup()
     assert con.status == Status.INVALID
     for _ in range(3):
@@ -78,12 +81,13 @@ def test_condition_node():
     assert con.status == Status.SUCCESS
 
 
-def test_condition_node_with_arg():
+def test_condition_node_with_arg(bt_cleaner):
     def check(val):
         return val
 
     value = False
     con = ConditionNode("con", check, value)
+    bt_cleaner.register(con)
     con.setup()
     assert con.status == Status.INVALID
     for _ in range(3):

--- a/beams/tests/test_tree_generator.py
+++ b/beams/tests/test_tree_generator.py
@@ -19,9 +19,10 @@ def test_tree_obj_ser():
     assert isinstance(tg.root, CheckAndDo)
 
 
-def test_tree_obj_execution(request):
+def test_tree_obj_execution(request, bt_cleaner):
     fname = Path(__file__).parent / "artifacts" / "eggs.json"
     tree = get_tree_from_path(fname)
+    bt_cleaner.register(tree)
 
     # start mock IOC # NOTE: assumes test is being run from top level of
     run_example_ioc(
@@ -43,7 +44,7 @@ def test_tree_obj_execution(request):
     assert rel_val >= 100
 
 
-def test_father_tree_execution(request):
+def test_father_tree_execution(request, bt_cleaner):
     run_example_ioc(
         "beams.tests.mock_iocs.ImagerNaysh",
         request=request,
@@ -52,6 +53,7 @@ def test_father_tree_execution(request):
 
     fname = Path(__file__).parent / "artifacts" / "eggs2.json"
     tree = get_tree_from_path(fname)
+    bt_cleaner.register(tree)
     tree.setup()
     ct = 0
     while (
@@ -79,7 +81,7 @@ def test_save_tree_item_round_trip(tmp_path: Path):
     assert loaded_tree.root.name == item.name
 
 
-def test_stop_hitting_yourself(request):
+def test_stop_hitting_yourself(request, bt_cleaner):
     run_example_ioc(
         "beams.tests.mock_iocs.IM2L0",
         request=request,
@@ -88,6 +90,7 @@ def test_stop_hitting_yourself(request):
 
     fname = Path(__file__).parent / "artifacts" / "im2l0_test.json"
     tree = get_tree_from_path(fname)
+    bt_cleaner.register(tree)
     tree.setup()
     ct = 0
     while (

--- a/docs/source/upcoming_release_notes/70-tst_end_spam.rst
+++ b/docs/source/upcoming_release_notes/70-tst_end_spam.rst
@@ -1,0 +1,24 @@
+70 tst_end_spam
+###############
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Clean up shutdown logic for ``ActionNode``
+- Clean up test suite atexit spam by providing a ``bt_cleanup``
+- Remove flaky mark warning from pytest runs
+
+Contributors
+------------
+- zllentz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ file = "docs-requirements.txt"
 
 [tool.pytest.ini_options]
 addopts = "--cov=."
+markers = [
+    "flaky: register this mark to avoid pytest warnings (comes from caproto -> pytest-rerunfailures)",
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `shutdown` method to `ActionNode` to clean up the worker on shutdown. `py_trees` describes this as something like "the opposite of `setup`" so since we set the worker up in `setup`, this seems like the canonical place to clean up the worker. 
- Tweak `ActionNode`'s logic so it only cleans up the worker once.
- Create a helper for the test suite that can be used to register behavior trees and nodes for cleanup at the end of a unit test. This will effectively stop the workers between tests.
- Apply this helper to all the tests that need it.
- Register a dummy "flaky" mark

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Stopping work with the `atexit` hook is correct and necessary, but causes issues (spam) in `pytest` due to some sort of cleanup ordering that I wasn't able to pin down.
- In other cases (qtbot) there is precedence for making sure each test cleans itself up.
- The `flaky` mark is used in `caproto` and comes from `pytest-rerunfailures`. Since we don't want to use flaky tests, instead I opted to register the mark so pytest would stop complaining about it existing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests still work
Unit tests no longer spam on exit

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
