### PR TITLE
Abstraction of Serialized Value && Reseting IOC By Tree

### DIFF
--- a/beams/tests/artifacts/egg_generator.py
+++ b/beams/tests/artifacts/egg_generator.py
@@ -10,7 +10,6 @@ from apischema import serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
 from beams.tree_config.base import BehaviorTreeItem
-from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import (BinaryConditionItem,
                                          BoundedConditionItem,
@@ -18,6 +17,7 @@ from beams.tree_config.condition import (BinaryConditionItem,
 from beams.tree_config.idiom import CheckAndDoItem
 from beams.tree_config.py_trees import (RunningItem, StatusQueueItem,
                                         SuccessItem)
+from beams.tree_config.value import EPICSValue, FixedValue
 
 
 # egg 1

--- a/beams/tests/artifacts/egg_generator.py
+++ b/beams/tests/artifacts/egg_generator.py
@@ -9,7 +9,8 @@ import py_trees
 from apischema import serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
-from beams.tree_config.base import BehaviorTreeItem, EPICSValue, FixedValue
+from beams.tree_config.base import BehaviorTreeItem
+from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import (BinaryConditionItem,
                                          BoundedConditionItem,

--- a/beams/tests/mock_iocs/SysResetIOC.py
+++ b/beams/tests/mock_iocs/SysResetIOC.py
@@ -11,7 +11,7 @@ class MockSysResetIOC(PVGroup):
 
   heartbeat = pvproperty(
         name="HEARTBEAT",
-        value=0,
+        value=4000,
         dtype=int,
         doc="Represents heartbeat of IOC, monotonically increasing (until reset)")
   sys_reset = pvproperty(

--- a/beams/tests/mock_iocs/SysResetIOC.py
+++ b/beams/tests/mock_iocs/SysResetIOC.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from textwrap import dedent
+
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+
+class MockSysResetIOC(PVGroup):
+  """
+  IOC to mock SLACEPICS IOCs with respect to how they increment heartbeat and are reset
+  """
+
+  heartbeat = pvproperty(
+        name="HEARTBEAT",
+        value=0,
+        dtype=int,
+        doc="Represents heartbeat of IOC, monotonically increasing (until reset)")
+  sys_reset = pvproperty(
+        name="SysReset",
+        value=0,
+        dtype=int,
+        doc="Rising edge indicates requested reset, put high to request reset")
+
+  @sys_reset.putter
+  async def sys_reset(self, instance, value):
+      await self.heartbeat.write(0)
+      return 0
+
+  @heartbeat.scan(period=1.0)
+  async def heartbeat(self, instance, async_lib):
+    print(instance.value)
+    await instance.write(instance.value+1)
+
+
+if __name__ == "__main__":
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="SysResetTest:", desc=dedent(MockSysResetIOC.__doc__)
+    )
+    ioc = MockSysResetIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/beams/tests/test_bin.py
+++ b/beams/tests/test_bin.py
@@ -15,9 +15,9 @@ from beams.bin.gen_test_ioc_main import collect_pv_info
 from beams.bin.main import main
 from beams.tests.conftest import cli_args, restore_logging
 from beams.tree_config import save_tree_item_to_path
-from beams.tree_config.value import EPICSValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem
+from beams.tree_config.value import EPICSValue
 
 logger = logging.getLogger(__name__)
 

--- a/beams/tests/test_bin.py
+++ b/beams/tests/test_bin.py
@@ -15,7 +15,7 @@ from beams.bin.gen_test_ioc_main import collect_pv_info
 from beams.bin.main import main
 from beams.tests.conftest import cli_args, restore_logging
 from beams.tree_config import save_tree_item_to_path
-from beams.tree_config.base import EPICSValue
+from beams.tree_config.value import EPICSValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem
 

--- a/beams/tests/test_serialize.py
+++ b/beams/tests/test_serialize.py
@@ -2,10 +2,10 @@ from apischema import deserialize, serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
 from beams.tree_config.base import BehaviorTreeItem
-from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem, ConditionOperator
 from beams.tree_config.idiom import CheckAndDoItem
+from beams.tree_config.value import EPICSValue, FixedValue
 
 
 def test_serialize_check_and_do():

--- a/beams/tests/test_serialize.py
+++ b/beams/tests/test_serialize.py
@@ -1,7 +1,8 @@
 from apischema import deserialize, serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
-from beams.tree_config.base import BehaviorTreeItem, EPICSValue, FixedValue
+from beams.tree_config.base import BehaviorTreeItem
+from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem, ConditionOperator
 from beams.tree_config.idiom import CheckAndDoItem

--- a/beams/tests/test_utility_trees.py
+++ b/beams/tests/test_utility_trees.py
@@ -26,4 +26,6 @@ def test_sys_reset(request, bt_cleaner):
     ):
         for n in reset_ioc_tree.tick():
             print(n)
-            time.sleep(1)
+            time.sleep(0.01)
+
+    assert reset_ioc_tree.status == py_trees.common.Status.SUCCESS

--- a/beams/tests/test_utility_trees.py
+++ b/beams/tests/test_utility_trees.py
@@ -1,0 +1,29 @@
+import time
+
+import py_trees
+from caproto.tests.conftest import run_example_ioc
+
+from beams.tree_config.utility_trees.reset_ioc import ResetIOCItem
+
+
+def test_sys_reset(request, bt_cleaner):
+    reset_ioc_tree = ResetIOCItem(
+                        ioc_prefix="SysResetTest").get_tree()
+
+    bt_cleaner.register(reset_ioc_tree)
+
+    # start mock IOC # NOTE: assumes test is being run from top level of
+    run_example_ioc(
+        "beams.tests.mock_iocs.SysResetIOC",
+        request=request,
+        pv_to_check="SysResetTest:HEARTBEAT",
+    )
+
+    reset_ioc_tree.setup_with_descendants()
+    while reset_ioc_tree.status not in (
+        py_trees.common.Status.SUCCESS,
+        py_trees.common.Status.FAILURE,
+    ):
+        for n in reset_ioc_tree.tick():
+            print(n)
+            time.sleep(1)

--- a/beams/tree_config/base.py
+++ b/beams/tree_config/base.py
@@ -1,9 +1,7 @@
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 import py_trees
-from epics import caget
 from py_trees.behaviour import Behaviour
 
 from beams.serialization import as_tagged_union
@@ -38,35 +36,3 @@ class ExternalItem(BaseItem):
         # grab file
         # de-serialize tree, return it
         raise NotImplementedError
-
-
-@as_tagged_union
-@dataclass
-class BaseValue:
-    def get_value(self) -> Any:
-        raise NotImplementedError
-
-
-@dataclass
-class FixedValue(BaseValue):
-    value: Any
-
-    def get_value(self) -> Any:
-        return self.value
-
-
-@dataclass
-class EPICSValue(BaseValue):
-    pv_name: str
-    as_string: bool = False
-
-    def get_value(self) -> Any:
-        value = caget(self.pv_name, as_string=self.as_string)
-        logger.debug(f" <<-- (EPICSValue): caget({self.pv_name}) -> {value}")
-        return value
-
-
-@dataclass
-class OphydTarget(BaseValue):
-    device_name: str
-    component_path: list[str]

--- a/beams/tree_config/condition.py
+++ b/beams/tree_config/condition.py
@@ -1,3 +1,4 @@
+import logging
 import operator
 from dataclasses import dataclass, field
 from enum import Enum
@@ -7,6 +8,8 @@ from beams.serialization import as_tagged_union
 from beams.tree_config.base import BaseItem
 from beams.tree_config.value import BaseValue, FixedValue
 from beams.typing_helper import Evaluatable
+
+logger = logging.getLogger(__name__)
 
 
 @as_tagged_union
@@ -57,7 +60,9 @@ class BinaryConditionItem(BaseConditionItem):
             # TODO: determine if we want to do NULL handling should we get a value but it is None type
             rhs = self.right_value.get_value()
 
-            return op(lhs, rhs)
+            eval = op(lhs, rhs)
+            logger.debug(f"Evalling as lhs {lhs}, rhs {rhs}: {eval}")
+            return eval
 
         return cond_func
 

--- a/beams/tree_config/condition.py
+++ b/beams/tree_config/condition.py
@@ -4,7 +4,8 @@ from enum import Enum
 
 from beams.behavior_tree.condition_node import ConditionNode
 from beams.serialization import as_tagged_union
-from beams.tree_config.base import BaseItem, BaseValue, FixedValue
+from beams.tree_config.base import BaseItem
+from beams.tree_config.value import BaseValue, FixedValue
 from beams.typing_helper import Evaluatable
 
 

--- a/beams/tree_config/idiom.py
+++ b/beams/tree_config/idiom.py
@@ -49,4 +49,3 @@ class UseCheckConditionItem(BaseConditionItem):
 
     If used in any other context the tree will not be constructable.
     """
-    ...

--- a/beams/tree_config/utility_trees/reset_ioc.py
+++ b/beams/tree_config/utility_trees/reset_ioc.py
@@ -9,7 +9,8 @@ from beams.behavior_tree.action_node import ActionNode, wrapped_action_work
 from beams.tree_config.action import SetPVActionItem
 from beams.tree_config.base import BaseItem
 from beams.tree_config.condition import BinaryConditionItem, ConditionOperator
-from beams.tree_config.value import BlackBoardValue, EPICSValue
+from beams.tree_config.value import EPICSValue, ProcessIntValue
+from beams.typing_helper import Evaluatable
 
 logger = logging.getLogger(__name__)
 
@@ -18,31 +19,29 @@ logger = logging.getLogger(__name__)
 class ResetIOCItem(BaseItem):
     ioc_prefix: str = ""
     # semi static member objects
-    HEARTBEAT_POSTFIX: str = ":HEARTBEART"
+    HEARTBEAT_POSTFIX: str = ":HEARTBEAT"
     SYSRESET_POSTFIX: str = ":SysReset"
     HEARTBEAT_KEY_NAME: str = "heartbeat"
 
     def __post_init__(self):
         # non dataclass PVss
-        self.hbeat_val = BlackBoardValue(bb_name=f"{self.ioc_prefix}_reset",
-                                         key_name=self.HEARTBEAT_KEY_NAME)
+        self.hbeat_val = ProcessIntValue(value=-1)  # set to unachievable heartbeat val 
         self.name = f"{self.ioc_prefix}_reset_tree"
 
     def get_tree(self) -> Sequence:
         def check_acquired_current_hbeat():
-            val = self.hbeat_val.get_value() is not None
-            logger.debug(f"checking opur guy as {val}")
+            val = self.hbeat_val.get_value() != -1  # set to unachievable heartbeat val 
+            logger.debug(f"Heartbeat cached as {val}, {self.hbeat_val.get_value()}")
             return val
 
         # get the current heartbeat of IOC
-        @wrapped_action_work(loop_period_sec=3.0)
-        def cache_hbeat_wfunc():
-            bb_client = py_trees.blackboard.Client(name=self.bb_name)
-            bb_client.register_key(key=self.HEARTBEAT_KEY_NAME, access=py_trees.common.Access.WRITE)
-
+        @wrapped_action_work(loop_period_sec=0.1)
+        def cache_hbeat_wfunc(comp_condition: Evaluatable) -> py_trees.common.Status:
             current_hbeat = caget(self.ioc_prefix+self.HEARTBEAT_POSTFIX)
-            bb_client.set(f"{self.HEARTBEAT_KEY_NAME}", current_hbeat)
-            logger.debug(f"<<-- Aquired ioc: {self.ioc_prefix} hbeat count: {current_hbeat} and put to blackboard")
+            self.hbeat_val.set_value(current_hbeat)
+            logger.debug(f"<<-- Aquired ioc hbeat: {self.ioc_prefix} hbeat count: {current_hbeat}")
+
+            return py_trees.common.Status.SUCCESS
 
         cache_current_heartbeat = ActionNode(name=f"{self.ioc_prefix}_hbeat_cache",
                                              work_func=cache_hbeat_wfunc,
@@ -57,10 +56,10 @@ class ResetIOCItem(BaseItem):
         send_reset = SetPVActionItem(name=f"reset_{self.ioc_prefix}",
                                      pv=f"{self.ioc_prefix}:SysReset",
                                      value=1,
-                                     loop_period_sec=3.0,  # this is greater than work_timeout period, should only happen once.
+                                     loop_period_sec=0.1,  # this is greater than work_timeout period, should only happen once.
                                      termination_check=reset_success_termination_condiiton)
 
         root = Sequence(name=self.name,
-                        memory=False,
+                        memory=True,
                         children=[cache_current_heartbeat, send_reset.get_tree()])
         return root

--- a/beams/tree_config/utility_trees/reset_ioc.py
+++ b/beams/tree_config/utility_trees/reset_ioc.py
@@ -25,12 +25,12 @@ class ResetIOCItem(BaseItem):
 
     def __post_init__(self):
         # non dataclass PVss
-        self.hbeat_val = ProcessIntValue(value=-1)  # set to unachievable heartbeat val 
+        self.hbeat_val = ProcessIntValue(value=-1)  # set to unachievable heartbeat val
         self.name = f"{self.ioc_prefix}_reset_tree"
 
     def get_tree(self) -> Sequence:
         def check_acquired_current_hbeat():
-            val = self.hbeat_val.get_value() != -1  # set to unachievable heartbeat val 
+            val = self.hbeat_val.get_value() != -1  # set to unachievable heartbeat val
             logger.debug(f"Heartbeat cached as {val}, {self.hbeat_val.get_value()}")
             return val
 
@@ -59,7 +59,18 @@ class ResetIOCItem(BaseItem):
                                      loop_period_sec=0.1,  # this is greater than work_timeout period, should only happen once.
                                      termination_check=reset_success_termination_condiiton)
 
+        # get the current heartbeat of IOC
+        @wrapped_action_work(loop_period_sec=0.1)
+        def reset_cache_hbeat_wfunc(comp_condition: Evaluatable) -> py_trees.common.Status:
+            self.hbeat_val.set_value(-1)
+            logger.debug(f"<<-- Resetting cached ioc hbeat for tree: {self.ioc_prefix}")
+
+            return py_trees.common.Status.SUCCESS
+        reset_heartbeat_cache = ActionNode(name=f"{self.ioc_prefix}_reset_heartbeat_cache",
+                                           work_func=reset_cache_hbeat_wfunc,
+                                           completion_condition=lambda : self.hbeat_val.get_value() == -1)
+
         root = Sequence(name=self.name,
                         memory=True,
-                        children=[cache_current_heartbeat, send_reset.get_tree()])
+                        children=[cache_current_heartbeat, send_reset.get_tree(), reset_heartbeat_cache])
         return root

--- a/beams/tree_config/utility_trees/reset_ioc.py
+++ b/beams/tree_config/utility_trees/reset_ioc.py
@@ -1,0 +1,65 @@
+import logging
+from dataclasses import dataclass
+
+import py_trees
+from py_trees.composites import Sequence
+
+from epics import caget
+
+from beams.behavior_tree.action_node import ActionNode, wrapped_action_work
+
+from beams.tree_config.base import BaseItem
+from beams.tree_config.value import BlackBoardValue, EPICSValue
+from beams.tree_config.action import SetPVActionItem
+from beams.tree_config.condition import BinaryConditionItem, ConditionOperator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResetIOCItem(BaseItem):
+    ioc_prefix: str = ""
+    HEARTBEAT_POSTFIX = ":HEARTBEART"
+    SYSRESET_POSTFIX = ":SysReset"
+    HEARTBEAT_KEY_NAME = "heartbeat"
+
+    def __post_init__(self):
+        # non dataclass PVss
+        self.hbeat_val = BlackBoardValue(bb_name=f"{self.ioc_prefix}_reset",
+                                         key_name=self.HEARTBEAT_KEY_NAME) 
+        self.name = f"{self.ioc_prefix}_reset_tree"
+
+    def get_tree(self) -> Sequence:
+        def check_acquired_current_hbeat():
+            self.hbeat_val.get_value() is not None
+        
+        # get the current heartbeat of IOC
+        @wrapped_action_work(loop_period_sec=3.0)
+        def cache_hbeat_wfunc():
+            bb_client = py_trees.blackboard.Client(name=self.bb_name)
+            bb_client.register_key(key=self.HEARTBEAT_KEY_NAME, access=py_trees.common.Access.WRITE)
+
+            current_hbeat = caget(self.ioc_prefix+self.HEARTBEAT_POSTFIX)
+            bb_client.set(f"{self.HEARTBEAT_KEY_NAME}", current_hbeat)
+            logger.debug(f"<<-- Aquired ioc: {self.ioc_prefix} hbeat count: {current_hbeat} and put to blackboard")
+
+        cache_current_heartbeat = ActionNode(name=f"{self.ioc_prefix}_hbeat_cache",
+                                             work_func=cache_hbeat_wfunc,
+                                             completion_condition=check_acquired_current_hbeat
+                                             )
+
+        # send the reset command
+        reset_success_termination_condiiton = BinaryConditionItem(
+                                                left_value=EPICSValue(pv_name=f"{self.ioc_prefix+self.HEARTBEAT_POSTFIX}"),
+                                                right_value=self.hbeat_val,
+                                                operator=ConditionOperator.less)
+        send_reset = SetPVActionItem(name=f"reset_{self.ioc_prefix}",
+                                     pv=f"{self.ioc_prefix}:SysReset",
+                                     value=1,
+                                     loop_period_sec=3.0,  # this is greater than work_timeout period, should only happen once. 
+                                     termination_check=reset_success_termination_condiiton)
+
+        root = Sequence(name=self.name,
+                        memory=False,
+                        children=[cache_current_heartbeat, send_reset])
+        return root

--- a/beams/tree_config/value.py
+++ b/beams/tree_config/value.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any
 from dataclasses import dataclass
+from typing import Any
 
 import py_trees
 from epics import caget
+
 from beams.serialization import as_tagged_union
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class EPICSValue(BaseValue):
         return value
 
 
+@dataclass
 class BlackBoardValue(BaseValue):
     bb_name: str = ""
     key_name: str = ""

--- a/beams/tree_config/value.py
+++ b/beams/tree_config/value.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any
+from dataclasses import dataclass
+
+import py_trees
+from epics import caget
+from beams.serialization import as_tagged_union
+
+logger = logging.getLogger(__name__)
+
+
+@as_tagged_union
+@dataclass
+class BaseValue:
+    def get_value(self) -> Any:
+        raise NotImplementedError
+
+
+@dataclass
+class FixedValue(BaseValue):
+    value: Any
+
+    def get_value(self) -> Any:
+        return self.value
+
+
+@dataclass
+class EPICSValue(BaseValue):
+    pv_name: str
+    as_string: bool = False
+
+    def get_value(self) -> Any:
+        value = caget(self.pv_name, as_string=self.as_string)
+        logger.debug(f" <<-- (EPICSValue): caget({self.pv_name}) -> {value}")
+        return value
+
+
+class BlackBoardValue(BaseValue):
+    bb_name: str = ""
+    key_name: str = ""
+
+    def get_value(self) -> Any:
+        logger.debug(f" <<-- (BlackBoardValue): checking blackboard: {self.bb_name} \
+                      for key {self.key_name}")
+        bb_client = py_trees.blackboard.Client(name=self.bb_name)
+        try:
+            value = bb_client.get(self.key_name)
+        except AttributeError:  # Note: seems like it should be KeyError, but in practice getting this one
+            logger.error(f"<<-- In blackboard: {self.bb_name} \
+                          key {self.key_name} does not exist \
+                          returning None")
+            return None
+        return value
+
+
+@dataclass
+class OphydTarget(BaseValue):
+    device_name: str
+    component_path: list[str]

--- a/examples/mfx_dg1/mfx_tree.py
+++ b/examples/mfx_dg1/mfx_tree.py
@@ -2,13 +2,13 @@ from pathlib import Path
 
 from beams.tree_config import save_tree_item_to_path
 from beams.tree_config.action import SetPVActionItem
-from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import (SelectorItem, SequenceConditionItem,
                                          SequenceItem)
 from beams.tree_config.condition import (BinaryConditionItem,
                                          BoundedConditionItem,
                                          ConditionOperator)
 from beams.tree_config.idiom import CheckAndDoItem
+from beams.tree_config.value import EPICSValue, FixedValue
 
 # DG2 Stopper: remove
 check_dg2_stp_not_open = BinaryConditionItem(

--- a/examples/mfx_dg1/mfx_tree.py
+++ b/examples/mfx_dg1/mfx_tree.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from beams.tree_config import save_tree_item_to_path
 from beams.tree_config.action import SetPVActionItem
-from beams.tree_config.base import EPICSValue, FixedValue
+from beams.tree_config.value import EPICSValue, FixedValue
 from beams.tree_config.composite import (SelectorItem, SequenceConditionItem,
                                          SequenceItem)
 from beams.tree_config.condition import (BinaryConditionItem,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description and Motivation and Context
A feature that was requested by scientists was the ability to reset IOCs by tree. This inspired the advent of `utility_trees`. Utility trees differ from `idioms` in this way: _idioms_ specify a tree structure _utility trees_ are a specific instantiation of a tree structure. This allows tree functionality specific process variables be stored within the object representing the utility tree. This is present in the "reset ioc" utility tree in the cached `hbeat_val` representing the runtime polled heartbeat value of the ioc due to be reset such that we can ensure on reset the value is less than the original. 


The tree structure takes the form of "get hbeat val then perform check and do to confirm reset of hbeat value. The check and do is of form SetPV and sets the SysReset pv. And a final action which resets the cached heartbeat to negative 1 such that future cache's will be successful.

<img src="https://github.com/user-attachments/assets/fd758f64-81d3-49d5-8bcb-3c17222fe9d0" alt="Alt Text" width="300" height="200">


### Note for future development:
All of this strongly motivates another type of non persistent action node. Josh's initial operational speccing on needing _all_ action nodes to be persistent was over-zealous. We can and should design an async or spawnable & joinable action node as well...

## How Has This Been Tested?
caproto IOCs don't natively seem to mock this "reset ioc by PV" interface, though there are [_some_](https://caproto.github.io/caproto/master/generated/caproto.server.stats.BasicStatusHelper.html) references to it in documentation but only if one actually uses caproto via procServ? So I just mocked the PVs within a mock_ioc that increments the hbeat count via the scan property. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
