### PR TITLE
Loading trees into memory of BeamsService and ticking those trees

### DIFF
--- a/beams/behavior_tree/action_node.py
+++ b/beams/behavior_tree/action_node.py
@@ -58,8 +58,8 @@ class ActionNode(py_trees.behaviour.Behaviour):
         """
         Initialise configures and resets the behaviour ready for (repeated) execution
         """
-        logger.debug(f"{self.name}.initialise [{self.status.name}->RUNNING]")
         self.volatile_status.set_value(py_trees.common.Status.RUNNING)
+        logger.debug(f"{self.name}.initialise [{self.status.name}->RUNNING]")
         self.work_gate.set()
 
     def update(self) -> py_trees.common.Status:
@@ -87,3 +87,4 @@ class ActionNode(py_trees.behaviour.Behaviour):
             "%s.terminate [%s->%s]"
             % (self.name, self.status.name, new_status.name)
         )
+        logger.debug("Work process joined")

--- a/beams/behavior_tree/action_node.py
+++ b/beams/behavior_tree/action_node.py
@@ -49,9 +49,11 @@ class ActionNode(py_trees.behaviour.Behaviour):
         )  # TODO(josh): make sure this cleans up resources when it dies
         self.is_set_up = True
 
+    # https://py-trees.readthedocs.io/en/devel/modules.html#py_trees.behaviour.Behaviour.shutdown
     def shutdown(self) -> None:
         if self.is_set_up:
             self.worker.stop_work()
+            logger.debug("Work process joined")
             self.is_set_up = False
 
     def initialise(self) -> None:
@@ -87,4 +89,3 @@ class ActionNode(py_trees.behaviour.Behaviour):
             "%s.terminate [%s->%s]"
             % (self.name, self.status.name, new_status.name)
         )
-        logger.debug("Work process joined")

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -1,9 +1,3 @@
-<<<<<<< HEAD
-import sys
-import os
-=======
-# toss arg parse here to start
->>>>>>> d0aa23b (feat: ticking through trees loaded in memory!)
 import logging
 import os
 import sys
@@ -14,7 +8,7 @@ from beams.logging import setup_logging
 from beams.service.helpers.worker import Worker
 from beams.service.remote_calls.command_pb2 import CommandType
 from beams.service.rpc_handler import RPCHandler
-from beams.service.tree_ticker import TreeTicker, TreeState
+from beams.service.tree_ticker import TreeState, TreeTicker
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +18,7 @@ class BeamsService(Worker):
         # TODO: make a singleton. Make process safe by leaving artifact file
         super().__init__("BeamsService", grace_window_before_terminate_seconds=0.5)
 
-         # remote manager: https://docs.python.org/3/library/multiprocessing.html#using-a-remote-manager
+        # remote manager: https://docs.python.org/3/library/multiprocessing.html#using-a-remote-manager
         class sync_man(BaseManager):
           pass
 
@@ -36,6 +30,14 @@ class BeamsService(Worker):
         self.sync_man = sync_man()
         self.sync_man.start()
         logger.debug(f"Sync Man starting at: {self.sync_man.address}")
+
+    def join_all_trees(self):
+        with self.sync_man as man:
+          tree_dict = man.get_tree_dict()
+          for tree_name, tree in tree_dict.items():
+              print(f"Cleaning up tree of name {tree_name}")
+              tree.stop_work()
+              tree.shutdown()
 
     def work_func(self):
         self.grpc_service = RPCHandler(sync_manager=self.sync_man)
@@ -50,32 +52,43 @@ class BeamsService(Worker):
                     logger.debug(f"inbound command {request}")
 
                     if (request.command_t == CommandType.LOAD_NEW_TREE):
-                        logger.debug(f"ayo no in man we're at: {os.getpid()}")
                         with self.sync_man as man:
-                          tick_config_mess = request.load_new_tree.tick_spec
-                          init_state = man.TreeState(
-                            tick_delay_ms=tick_config_mess.delay_ms,
-                            tick_config=tick_config_mess.tick_config
-                          )
-                          x = man.TreeTicker(filepath=request.load_new_tree.tree_file_path,
-                                             init_tree_state=init_state)
-                          tree_dict = man.get_tree_dict()
-                          tree_dict.update({request.tree_name : x})
-                          logger.debug(f"Loaded tree of name {request.tree_name}" +
-                                       f" from filepath: {request.load_new_tree.tree_file_path}" +
-                                       " explciit START_TREE command will need to be issued for it to begin")
+                            tick_config_mess = request.load_new_tree.tick_spec
+                            init_state = man.TreeState(
+                                tick_delay_ms=tick_config_mess.delay_ms,
+                                tick_config=tick_config_mess.tick_config
+                            )
+                            x = man.TreeTicker(filepath=request.load_new_tree.tree_file_path,
+                                               init_tree_state=init_state)
+                            tree_dict = man.get_tree_dict()
+                            tree_dict.update({request.tree_name : x})
+                            logger.debug(f"Loaded tree of name {request.tree_name}" +
+                                         f" from filepath: {request.load_new_tree.tree_file_path}" +
+                                         " explciit START_TREE command will need to be issued for it to begin")
                     elif (request.command_t == CommandType.START_TREE):
-                      with self.sync_man as man:
-                        # get tree, again for now this is tree specified in json file,
-                        # disambugiate this later
-                        tree_name = request.tree_name
-                        # get tree
-                        tree_dict = man.get_tree_dict()
-                        if (tree_name not in tree_dict.keys()):
-                          logging.error(f"Sorry fam {tree_name} is not in tree_dictionary: {tree_dict}")
-                          continue
-                        tree_to_start = tree_dict.get(tree_name)
-                        tree_to_start.start_tree()
+                        with self.sync_man as man:
+                            # get tree, again for now this is tree specified in json file,
+                            # disambugiate this later
+                            tree_name = request.tree_name
+                            # get tree
+                            tree_dict = man.get_tree_dict()
+                            if (tree_name not in tree_dict.keys()):
+                                logging.error(f"{tree_name} is not in tree_dictionary: {tree_dict}")
+                                continue
+                            tree_to_start = tree_dict.get(tree_name)
+                            tree_to_start.start_tree()
+                    elif (request.command_t == CommandType.PAUSE_TREE):
+                        with self.sync_man as man:
+                            # get tree, again for now this is tree specified in json file,
+                            # disambugiate this later
+                            tree_name = request.tree_name
+                            # get tree
+                            tree_dict = man.get_tree_dict()
+                            if (tree_name not in tree_dict.keys()):
+                                logging.error(f"{tree_name} is not in tree_dictionary: {tree_dict}")
+                                continue
+                            tree_to_start = tree_dict.get(tree_name)
+                            tree_to_start.pause_tree()
 
             except Exception as e:
                 e_type, e_object, e_traceback = sys.exc_info()
@@ -104,6 +117,7 @@ def main(*args, **kwargs):
 
     while (input("press q to kill") != 'q'):
       time.sleep(1)
+    x.join_all_trees()
     x.stop_work()
 
 

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -1,9 +1,16 @@
+<<<<<<< HEAD
 import sys
 import os
+=======
+# toss arg parse here to start
+>>>>>>> d0aa23b (feat: ticking through trees loaded in memory!)
 import logging
+import os
+import sys
 import time
 from multiprocessing.managers import BaseManager
 
+from beams.logging import setup_logging
 from beams.service.helpers.worker import Worker
 from beams.service.remote_calls.command_pb2 import CommandType
 from beams.service.rpc_handler import RPCHandler
@@ -17,22 +24,21 @@ class BeamsService(Worker):
         # TODO: make a singleton. Make process safe by leaving artifact file
         super().__init__("BeamsService", grace_window_before_terminate_seconds=0.5)
 
-        # pattern inheritted:
-        # remote manager: https://docs.python.org/3/library/multiprocessing.html#using-a-remote-manager
-        class MyManager(BaseManager):
+         # remote manager: https://docs.python.org/3/library/multiprocessing.html#using-a-remote-manager
+        class sync_man(BaseManager):
           pass
 
         self.tree_dict = {}
-        MyManager.register("TreeTicker", TreeTicker)
-        MyManager.register("TreeState", TreeTicker.TreeState)  # , exposed=('current_node', "tick_config", "tick_delay_ms")
-        MyManager.register("get_tree_dict", callable=lambda: self.tree_dict)
+        sync_man.register("TreeTicker", TreeTicker)
+        sync_man.register("TreeState", TreeTicker.TreeState)  # , exposed=('current_node', "tick_config", "tick_delay_ms")
+        sync_man.register("get_tree_dict", callable=lambda: self.tree_dict)
 
-        self.MyManager = MyManager()
-        self.MyManager.start()
-        logger.debug(f"Sync Man starting at: {self.MyManager.address}")
+        self.sync_man = sync_man()
+        self.sync_man.start()
+        logger.debug(f"Sync Man starting at: {self.sync_man.address}")
 
     def work_func(self):
-        self.grpc_service = RPCHandler(sync_manager=self.MyManager)
+        self.grpc_service = RPCHandler(sync_manager=self.sync_man)
         self.grpc_service.start_work()
 
         # the job of this work function will be to consume messages and update the managed trees
@@ -44,7 +50,8 @@ class BeamsService(Worker):
                     logger.debug(f"inbound command {request}")
 
                     if (request.command_t == CommandType.LOAD_NEW_TREE):
-                        with self.MyManager as man:
+                        logger.debug(f"ayo no in man we're at: {os.getpid()}")
+                        with self.sync_man as man:
                           tick_config_mess = request.load_new_tree.tick_spec
                           init_state = man.TreeState(
                             tick_delay_ms=tick_config_mess.delay_ms,
@@ -57,6 +64,18 @@ class BeamsService(Worker):
                           logger.debug(f"Loaded tree of name {request.tree_name}" +
                                        f" from filepath: {request.load_new_tree.tree_file_path}" +
                                        " explciit START_TREE command will need to be issued for it to begin")
+                    elif (request.command_t == CommandType.START_TREE):
+                      with self.sync_man as man:
+                        # get tree, again for now this is tree specified in json file,
+                        # disambugiate this later
+                        tree_name = request.tree_name
+                        # get tree
+                        tree_dict = man.get_tree_dict()
+                        if (tree_name not in tree_dict.keys()):
+                          logging.error(f"Sorry fam {tree_name} is not in tree_dictionary: {tree_dict}")
+                          continue
+                        tree_to_start = tree_dict.get(tree_name)
+                        tree_to_start.start_tree()
 
             except Exception as e:
                 e_type, e_object, e_traceback = sys.exc_info()
@@ -89,5 +108,5 @@ def main(*args, **kwargs):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    setup_logging(logging.DEBUG)
     main()

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -14,7 +14,7 @@ from beams.logging import setup_logging
 from beams.service.helpers.worker import Worker
 from beams.service.remote_calls.command_pb2 import CommandType
 from beams.service.rpc_handler import RPCHandler
-from beams.service.tree_ticker import TreeTicker
+from beams.service.tree_ticker import TreeTicker, TreeState
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class BeamsService(Worker):
 
         self.tree_dict = {}
         sync_man.register("TreeTicker", TreeTicker)
-        sync_man.register("TreeState", TreeTicker.TreeState)  # , exposed=('current_node', "tick_config", "tick_delay_ms")
+        sync_man.register("TreeState", TreeState)
         sync_man.register("get_tree_dict", callable=lambda: self.tree_dict)
 
         self.sync_man = sync_man()

--- a/beams/service/helpers/worker.py
+++ b/beams/service/helpers/worker.py
@@ -5,6 +5,7 @@
 * Optional arg `stop_func` run on process termination before joining work process.
 """
 import logging
+import os
 import time
 from ctypes import c_bool
 from multiprocessing import Process, Value
@@ -39,14 +40,18 @@ class Worker():
                                      name=self.proc_name,
                                      args=(self.do_work, *self.add_args,))
         self.stop_func = stop_func
+        logger.debug(f"{self.proc_name} Instantiated on proc id: {os.getpid()}")
 
     def start_work(self):
         if self.do_work.value:
             logger.error(f"({self.proc_name}) -->>: Already working, cannot start")
             return
         self.do_work.value = True
+        logger.debug(f"Starting, parent proceess id is: {self.work_proc._parent_pid}")
         self.work_proc.start()
+        logger.debug(f"ON PROCESS {os.getpid()}")
         logger.debug(f"({self.proc_name}) -->>: Starting work")
+        logger.debug(f"Starting work for {self.proc_name} on proc id: {self.work_proc.pid}")
 
     def stop_work(self):
         logger.debug(f"({self.proc_name}) -->>: Calling stop work")

--- a/beams/service/rpc_handler.py
+++ b/beams/service/rpc_handler.py
@@ -43,14 +43,14 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         self.command_ready_sem = Semaphore(value=0)
 
     # NOTE: these could also live and work in a process spawned by beams service..
-
-    def attempt_to_get_tree_update(self, tree_name: str) -> Optional[BehaviorTreeUpdateMessage]:
+    # returns a single bt update as a list...
+    def attempt_to_get_tree_update(self, tree_name: str) -> Optional[List[BehaviorTreeUpdateMessage]]:
         if self.sync_man is None:  # for testing modularity
             return None
         with self.sync_man as my_boy:
             tree_dict = my_boy.get_tree_dict()
             if tree_name in tree_dict.keys():
-                return tree_dict.get(tree_name).get_behavior_tree_update()
+                return [tree_dict.get(tree_name).get_behavior_tree_update()]
             else:
                 logger.error(f"Unable to find tree of name {tree_name} currently being tickde")
                 return None
@@ -103,7 +103,7 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
 
         if updates is None:
             return hbeat_message
-        else: 
+        else:
             hbeat_message.behavior_tree_update.extend(updates)
             return hbeat_message
 

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -117,8 +117,6 @@ class TreeState():
         self.tick_current_tree = Value(c_bool, True)  # setting False will allow, stop_work / unloading
         self.pause_tree = Value(c_bool, True)  # start in paused state
 
-    # because I'm bad with @dataclass, and SyncManager.register only exposes "public", non __**__ functions these need public getters
-    # TODO: someone smart do better, i feel like you can add __get__ to exposed...
     def get_node_name(self):
         return self.current_node.value.decode()
 
@@ -168,6 +166,9 @@ class TreeTicker(Worker):
         # don't forget to null check this
         self.sync_man = sync_man
 
+    def shutdown(self):
+        self.tree.shutdown()
+
     def get_tree_state(self):
         return self.state
 
@@ -210,7 +211,7 @@ class TreeTicker(Worker):
     def start_tree(self):
         # if tree is in unpaused state throw error
         if (not self.state.get_pause_tree()):
-            logging.error(f"Tree of name {self.tree.root.name}")
+            logging.error(f"Tree of name {self.tree.root.name} is already unpaused")
             return
         self.state.set_pause_tree(False)
         # NOTE: this was moved here as the os.getpid() of the owning Process object
@@ -218,3 +219,10 @@ class TreeTicker(Worker):
         # from the same pid we created the object in. Is this flawless, no. Move at your own risk
         self.tree.setup()
         self.start_work()
+
+    def pause_tree(self):
+        # if tree is already paused log error
+        if (self.state.get_pause_tree()):
+            logging.error(f"Tree off name {self.tree.root.name} is already paused!!")
+        self.state.set_pause_tree(True)
+        logger.debug(f"Pausing tree of name {self.tree.root.name}")


### PR DESCRIPTION
## Description
The next logical step in this whole dealio - actually loading trees into service memory and ticking them so they do their job.

The big push of this was to do the loading into memory and process management, which python makes not fun to debug. 


## Nuances
### Process Spawning
1. Main thread spawns a process that handles work for beams_service. 
2. Beams_service process spawns:
  a. Process which handles RPC 
  b. Manager daemon[^1]
3. As per usual each action node spawns its own persistent process to handle its work[^2]

### Where the trees live
The trees are stored in a tree dictionary object that is accessed via the Manager for process safety things as in this design two processes will have to be aware of TreeState; the process the responds to HeartBeat messages and the process that handles commands.[^3] 

[^3]: there could've been a world where one process handles both of these, process locking becomes more trivial as the dictionary _could_ just live there and then the RPC process would just use a Pipe to get the contents of the HeartBeat message from that singular process; I found this equally convoluted and the use of a SyncManager, even if custom classed to hold our custom class, seemed more pythonic
 
[^2]: I am growing ever more amenable to action nodes not having their work persist for the entirety of the program.... for another PR

[^1]: To be 100% transparent, this is actually spawned on the mainthread because its called in the constructor of the BEAMSService object

## How Has This Been Tested?
Works

## Where Has This Been Documented?
Some design decisions probably need more highlighting

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
