### PR TITLE
feat: got interactive ticking on the service

### DIFF
--- a/beams/behavior_tree/action_node.py
+++ b/beams/behavior_tree/action_node.py
@@ -89,4 +89,3 @@ class ActionNode(py_trees.behaviour.Behaviour):
             "%s.terminate [%s->%s]"
             % (self.name, self.status.name, new_status.name)
         )
-        logger.debug("Work process joined")

--- a/beams/behavior_tree/action_node.py
+++ b/beams/behavior_tree/action_node.py
@@ -53,7 +53,7 @@ class ActionNode(py_trees.behaviour.Behaviour):
     def shutdown(self) -> None:
         if self.is_set_up:
             self.worker.stop_work()
-            logger.debug("Work process joined")
+            logger.debug(f"Work process for node {self.name} joined")
             self.is_set_up = False
 
     def initialise(self) -> None:

--- a/beams/behavior_tree/action_node.py
+++ b/beams/behavior_tree/action_node.py
@@ -89,3 +89,4 @@ class ActionNode(py_trees.behaviour.Behaviour):
             "%s.terminate [%s->%s]"
             % (self.name, self.status.name, new_status.name)
         )
+        logger.debug("Work process joined")

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -40,7 +40,7 @@ class BeamsService(Worker):
                 tree.stop_work()
                 tree.shutdown()
 
-    def work_func(self):
+    def work_func(self):  # noqa: C901, sorry I want this standalone PR to be a good case study, will remove in next
         self.grpc_service = RPCHandler(sync_manager=self.sync_man)
         self.grpc_service.start_work()
 
@@ -86,10 +86,22 @@ class BeamsService(Worker):
                             # get tree
                             tree_dict = man.get_tree_dict()
                             if (tree_name not in tree_dict.keys()):
-                                logging.error(f"{tree_name} is not in tree_dictionary: {tree_dict}")
+                                logging.error(f"Sorry fam {tree_name} is not in tree_dictionary: {tree_dict}")
                                 continue
                             tree_to_start = tree_dict.get(tree_name)
                             tree_to_start.pause_tree()
+                    elif (request.command_t == CommandType.TICK_TREE):
+                        with self.sync_man as man:
+                            # get tree, again for now this is tree specified in json file,
+                            # disambugiate this later
+                            tree_name = request.tree_name
+                            # get tree
+                            tree_dict = man.get_tree_dict()
+                            if (tree_name not in tree_dict.keys()):
+                                logging.error(f"Sorry fam {tree_name} is not in tree_dictionary: {tree_dict}")
+                                continue
+                            tree_to_start = tree_dict.get(tree_name)
+                            tree_to_start.command_tick()
 
             except Exception as e:
                 e_type, e_object, e_traceback = sys.exc_info()

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -116,7 +116,7 @@ def main(*args, **kwargs):
     x.start_work()
 
     while (input("press q to kill") != 'q'):
-      time.sleep(1)
+        time.sleep(1)
     x.join_all_trees()
     x.stop_work()
 

--- a/beams/bin/beams_service.py
+++ b/beams/bin/beams_service.py
@@ -1,3 +1,4 @@
+# toss arg parse here to start
 import logging
 import os
 import sys
@@ -33,11 +34,11 @@ class BeamsService(Worker):
 
     def join_all_trees(self):
         with self.sync_man as man:
-          tree_dict = man.get_tree_dict()
-          for tree_name, tree in tree_dict.items():
-              print(f"Cleaning up tree of name {tree_name}")
-              tree.stop_work()
-              tree.shutdown()
+            tree_dict = man.get_tree_dict()
+            for tree_name, tree in tree_dict.items():
+                logger.debug(f"Cleaning up tree of name {tree_name}")
+                tree.stop_work()
+                tree.shutdown()
 
     def work_func(self):
         self.grpc_service = RPCHandler(sync_manager=self.sync_man)

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -2,14 +2,6 @@
 Contains logic for 'threads' which need to tick behavior trees
 """
 from __future__ import annotations
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-=======
->>>>>>> 27d49aa (feat: loading trees into memory and reflecting that in the heartbeat)
-=======
-
->>>>>>> d0aa23b (feat: ticking through trees loaded in memory!)
 import logging
 import os
 import time

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -2,7 +2,10 @@
 Contains logic for 'threads' which need to tick behavior trees
 """
 from __future__ import annotations
+<<<<<<< HEAD
 
+=======
+>>>>>>> 27d49aa (feat: loading trees into memory and reflecting that in the heartbeat)
 import logging
 import os
 import time

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -3,9 +3,13 @@ Contains logic for 'threads' which need to tick behavior trees
 """
 from __future__ import annotations
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
 >>>>>>> 27d49aa (feat: loading trees into memory and reflecting that in the heartbeat)
+=======
+
+>>>>>>> d0aa23b (feat: ticking through trees loaded in memory!)
 import logging
 import os
 import time


### PR DESCRIPTION
## Description
Implementing tick interactive for our trees that are being managed by BEAMSService. 
Trying to break out of the mongo PR pattern. 

## Motivation and Context
We had continuous ticking down now we have interactive. Yay.

## How Has This Been Tested?
With the testing suite.

## Future thoughts:
All of this raises the good question.... How are we going to represent this to the UI via the client interface.
I can imagine a service endpoint: 
`GetTreeRepresentation(tree_name)`  that returns some serialization of tree state in such a way that can then be rendered by the client. 



<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
