### PR TITLE
adding abstraction and granularity to the values we seraliaze and compare too

### DIFF
--- a/beams/tests/artifacts/egg_generator.py
+++ b/beams/tests/artifacts/egg_generator.py
@@ -9,7 +9,7 @@ import py_trees
 from apischema import serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
-from beams.tree_config.base import BehaviorTreeItem, EPICSValue, FixedValue
+from beams.tree_config.base import BehaviorTreeItem
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import (BinaryConditionItem,
                                          BoundedConditionItem,
@@ -17,6 +17,7 @@ from beams.tree_config.condition import (BinaryConditionItem,
 from beams.tree_config.idiom import CheckAndDoItem
 from beams.tree_config.py_trees import (RunningItem, StatusQueueItem,
                                         SuccessItem)
+from beams.tree_config.value import EPICSValue, FixedValue
 
 
 # egg 1

--- a/beams/tests/test_bin.py
+++ b/beams/tests/test_bin.py
@@ -15,9 +15,9 @@ from beams.bin.gen_test_ioc_main import collect_pv_info
 from beams.bin.main import main
 from beams.tests.conftest import cli_args, restore_logging
 from beams.tree_config import save_tree_item_to_path
-from beams.tree_config.base import EPICSValue
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem
+from beams.tree_config.value import EPICSValue
 
 logger = logging.getLogger(__name__)
 

--- a/beams/tests/test_serialize.py
+++ b/beams/tests/test_serialize.py
@@ -1,10 +1,11 @@
 from apischema import deserialize, serialize
 
 from beams.tree_config.action import IncPVActionItem, SetPVActionItem
-from beams.tree_config.base import BehaviorTreeItem, EPICSValue, FixedValue
+from beams.tree_config.base import BehaviorTreeItem
 from beams.tree_config.composite import SequenceItem
 from beams.tree_config.condition import BinaryConditionItem, ConditionOperator
 from beams.tree_config.idiom import CheckAndDoItem
+from beams.tree_config.value import EPICSValue, FixedValue
 
 
 def test_serialize_check_and_do():

--- a/beams/tree_config/base.py
+++ b/beams/tree_config/base.py
@@ -1,9 +1,7 @@
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 import py_trees
-from epics import caget
 from py_trees.behaviour import Behaviour
 
 from beams.serialization import as_tagged_union
@@ -38,35 +36,3 @@ class ExternalItem(BaseItem):
         # grab file
         # de-serialize tree, return it
         raise NotImplementedError
-
-
-@as_tagged_union
-@dataclass
-class BaseValue:
-    def get_value(self) -> Any:
-        raise NotImplementedError
-
-
-@dataclass
-class FixedValue(BaseValue):
-    value: Any
-
-    def get_value(self) -> Any:
-        return self.value
-
-
-@dataclass
-class EPICSValue(BaseValue):
-    pv_name: str
-    as_string: bool = False
-
-    def get_value(self) -> Any:
-        value = caget(self.pv_name, as_string=self.as_string)
-        logger.debug(f" <<-- (EPICSValue): caget({self.pv_name}) -> {value}")
-        return value
-
-
-@dataclass
-class OphydTarget(BaseValue):
-    device_name: str
-    component_path: list[str]

--- a/beams/tree_config/condition.py
+++ b/beams/tree_config/condition.py
@@ -1,11 +1,15 @@
+import logging
 import operator
 from dataclasses import dataclass, field
 from enum import Enum
 
 from beams.behavior_tree.condition_node import ConditionNode
 from beams.serialization import as_tagged_union
-from beams.tree_config.base import BaseItem, BaseValue, FixedValue
+from beams.tree_config.base import BaseItem
+from beams.tree_config.value import BaseValue, FixedValue
 from beams.typing_helper import Evaluatable
+
+logger = logging.getLogger(__name__)
 
 
 @as_tagged_union
@@ -56,7 +60,9 @@ class BinaryConditionItem(BaseConditionItem):
             # TODO: determine if we want to do NULL handling should we get a value but it is None type
             rhs = self.right_value.get_value()
 
-            return op(lhs, rhs)
+            eval = op(lhs, rhs)
+            logger.debug(f"Evalling as lhs {lhs}, rhs {rhs}: {eval}")
+            return eval
 
         return cond_func
 

--- a/beams/tree_config/value.py
+++ b/beams/tree_config/value.py
@@ -1,0 +1,57 @@
+import logging
+from ctypes import c_int
+from dataclasses import dataclass
+from multiprocessing import Value
+from typing import Any
+
+from epics import caget
+
+from beams.serialization import as_tagged_union
+
+logger = logging.getLogger(__name__)
+
+
+@as_tagged_union
+@dataclass
+class BaseValue:
+    def get_value(self) -> Any:
+        raise NotImplementedError
+
+
+@dataclass
+class FixedValue(BaseValue):
+    value: Any
+
+    def get_value(self) -> Any:
+        return self.value
+
+
+@dataclass
+class EPICSValue(BaseValue):
+    pv_name: str
+    as_string: bool = False
+
+    def get_value(self) -> Any:
+        value = caget(self.pv_name, as_string=self.as_string)
+        logger.debug(f" <<-- (EPICSValue): caget({self.pv_name}) -> {value}")
+        return value
+
+
+@dataclass
+class ProcessIntValue():
+    value: int = 0
+
+    def __post_init__(self):
+        self._value = Value(c_int, self.value, lock=True)
+
+    def set_value(self, value):
+        self._value.value = value
+
+    def get_value(self) -> Any:
+        return self._value.value
+
+
+@dataclass
+class OphydTarget(BaseValue):
+    device_name: str
+    component_path: list[str]

--- a/examples/mfx_dg1/mfx_tree.py
+++ b/examples/mfx_dg1/mfx_tree.py
@@ -2,13 +2,13 @@ from pathlib import Path
 
 from beams.tree_config import save_tree_item_to_path
 from beams.tree_config.action import SetPVActionItem
-from beams.tree_config.base import EPICSValue, FixedValue
 from beams.tree_config.composite import (SelectorItem, SequenceConditionItem,
                                          SequenceItem)
 from beams.tree_config.condition import (BinaryConditionItem,
                                          BoundedConditionItem,
                                          ConditionOperator)
 from beams.tree_config.idiom import CheckAndDoItem
+from beams.tree_config.value import EPICSValue, FixedValue
 
 # DG2 Stopper: remove
 check_dg2_stp_not_open = BinaryConditionItem(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Worked with @tangkong a _while_ ago to add granularity to our values by creating a `BaseValue` class distinct from `BaseItem` 

This was done by moving `FixedValue` and `EPICSValue` out from the `tree_config/base.py` and into the new `tree_config/value.py` and having these items base themselves of the new class `BaseValue`. This also includes a new process safe value type: `ProcessIntValue`

## Motivation and Context
This can be seen largely as a chore commit; however, this important increase in granularity can let us programmatically retrieve values from a more diverse locations in memory / serializable locations.

## How Has This Been Tested?
Yep! 

## Where Has This Been Documented?
In this PR.....

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
