### PR TITLE
ENH: add ability to load client from config

### DIFF
--- a/beams/tests/config.cfg
+++ b/beams/tests/config.cfg
@@ -1,0 +1,3 @@
+[server]
+address = my_address
+port = 9999

--- a/beams/tests/test_rpc_client.py
+++ b/beams/tests/test_rpc_client.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -17,11 +19,53 @@ class MockStub:
         return "heartbeat requested"
 
 
+SAMPLE_CFG = Path(__file__).parent / "config.cfg"
+
+
+@pytest.fixture(scope='function')
+def xdg_config_patch(tmp_path):
+    config_home = tmp_path / 'xdg_config_home'
+    config_home.mkdir()
+    return config_home
+
+
+@pytest.fixture(scope='function')
+def beams_cfg(xdg_config_patch: Path):
+    # patch config discovery paths
+    xdg_cfg = os.environ.get("XDG_CONFIG_HOME", '')
+    beams_cfg_path = os.environ.get("BEAMS_CFG", '')
+
+    os.environ['XDG_CONFIG_HOME'] = str(xdg_config_patch)
+    os.environ['BEAMS_CFG'] = ''
+
+    beams_cfg_path = xdg_config_patch / "beams.cfg"
+    beams_cfg_path.symlink_to(SAMPLE_CFG)
+
+    yield str(beams_cfg_path)
+
+    # reset env vars
+    os.environ["BEAMS_CFG"] = str(beams_cfg_path)
+    os.environ["XDG_CONFIG_HOME"] = xdg_cfg
+
+
 @pytest.fixture(scope="function")
 def client() -> RPCClient:
     cl = RPCClient()
 
     return cl
+
+
+def test_from_cfg(beams_cfg: str):
+    client = RPCClient.from_config()
+    assert client.server_address == "my_address:9999"
+
+
+def test_find_config(beams_cfg: str):
+    assert beams_cfg == RPCClient.find_config()
+
+    # explicit BEAMS_CFG env var supercedes XDG_CONFIG_HOME
+    os.environ['BEAMS_CFG'] = 'other/cfg'
+    assert 'other/cfg' == RPCClient.find_config()
 
 
 @patch("beams.service.rpc_client.BEAMS_rpcStub", MockStub)

--- a/docs/source/upcoming_release_notes/89-enh_config_client.rst
+++ b/docs/source/upcoming_release_notes/89-enh_config_client.rst
@@ -1,0 +1,26 @@
+89 enh_config_client
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Add config file loading functionality to RPCClient.
+  Searches the following locations in order for a config file:
+  - ``$BEAMS_CFG`` (a full path to a config file)
+  - ``$XDG_CONFIG_HOME/{beams.cfg, .beams.cfg}`` (either filename)
+  - ``~/.config/{beams.cfg, .beams.cfg}``
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Simple config loading setup for `RPCClient`.  Currently only has server address information, but we could always add more

## Motivation and Context
We wanted some better way of storing and setting `RPCClient` information

## How Has This Been Tested?
Some basic tests have been added

## Where Has This Been Documented?
This PR, some docstrings.  The acceptable keys are noted in a docstring, but it should probably live somewhere else long term

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
