### PR TITLE
MNT: augment protos to report Tree status

### DIFF
--- a/beams/service/remote_calls/behavior_tree.proto
+++ b/beams/service/remote_calls/behavior_tree.proto
@@ -4,6 +4,7 @@ import "beams/service/remote_calls/generic_message.proto"; // MESSAGE_TYPE_BEHAV
 
 /* Behavior Tree Update related fields */
 
+// Names must match py_trees.common.Status fields precisely
 enum TickStatus {
   INVALID = 0;
   RUNNING = 1;
@@ -17,6 +18,13 @@ enum TickConfiguration {
   CONTINUOUS = 2;
 }
 
+enum TreeStatus {
+  IDLE = 0;
+  TICKING = 1;
+  WAITING_ACK = 2;
+  ERROR = 3;
+}
+
 message BehaviorTreeUpdateMessage {
   MessageType mess_t = 1; // MESSAGE_TYPE_BEHAVIOR_TREE_MESSAGE
   string tree_name = 2;
@@ -24,4 +32,5 @@ message BehaviorTreeUpdateMessage {
   TickStatus tick_status = 4;
   TickConfiguration tick_config= 5;
   int32 tick_delay_ms = 6;
+  TreeStatus tree_status = 7;
 }

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -155,21 +155,6 @@ class TreeState():
     def get_tick_delay_ms(self) -> int:
         return int(self.tick_delay_ms.value)
 
-    def set_pause_tree(self, value: bool):
-        logger.debug(f"setting pause tree on thread: {os.getpid()}")
-        if value:
-            self.tree_status.value = "IDLE".encode()
-        else:
-            self.tree_status.value = "TICKING".encode()
-
-    def get_pause_tree(self) -> bool:
-        logger.debug(f"checking pause tree on thread: {os.getpid()}")
-        tree_status = getattr(self.tree_status, "value", b"ERROR").decode()
-        return tree_status == "IDLE"
-
-    def get_tick_current_tree(self) -> bool:
-        return self.tick_current_tree.value
-
     def get_tree_status(self) -> TreeStatus:
         tree_status_name = getattr(self.tree_status, "value", b"ERROR").decode()
         status = getattr(TreeStatus, tree_status_name)
@@ -177,6 +162,21 @@ class TreeState():
 
     def set_tree_status(self, status: TreeStatus) -> None:
         self.tree_status.value = TreeStatus.Name(status).encode()
+
+    def set_pause_tree(self, value: bool):
+        logger.debug(f"setting pause tree on thread: {os.getpid()}")
+        if value:
+            self.set_tree_status(TreeStatus.IDLE)
+        else:
+            self.set_tree_status(TreeStatus.TICKING)
+
+    def get_pause_tree(self) -> bool:
+        logger.debug(f"checking pause tree on thread: {os.getpid()}")
+        tree_status = self.get_tree_status()
+        return tree_status == TreeStatus.IDLE
+
+    def get_tick_current_tree(self) -> bool:
+        return self.tick_current_tree.value
 
 
 class TreeTicker(Worker):

--- a/beams/tests/test_rpc_handshakes.py
+++ b/beams/tests/test_rpc_handshakes.py
@@ -46,8 +46,9 @@ def test_load_run_continuous_tree(rpc_client: RPCClient):
         tree_name="my_tree"
     )
 
+    wait_until(partial(assert_heartbeat_has_n_trees, rpc_client, 1))
     resp0 = rpc_client.get_heartbeat()
-    assert len(resp0.behavior_tree_update) == 0
+    assert resp0.behavior_tree_update[0].tree_status == TreeStatus.IDLE
     # tree name taken from json, not our setting
 
     rpc_client.start_tree("my_tree")
@@ -71,8 +72,9 @@ def test_load_interactive_tree(rpc_client: RPCClient):
         tree_name="my_tree"
     )
 
+    wait_until(partial(assert_heartbeat_has_n_trees, rpc_client, 1))
     resp0 = rpc_client.get_heartbeat()
-    assert len(resp0.behavior_tree_update) == 0
+    assert resp0.behavior_tree_update[0].tree_status == TreeStatus.IDLE
 
     # start tree, but don't tick
     rpc_client.start_tree("my_tree")

--- a/beams/tests/test_rpc_handshakes.py
+++ b/beams/tests/test_rpc_handshakes.py
@@ -1,7 +1,7 @@
 from functools import partial
 from pathlib import Path
 
-from beams.service.remote_calls.behavior_tree_pb2 import TickStatus
+from beams.service.remote_calls.behavior_tree_pb2 import TickStatus, TreeStatus
 from beams.service.remote_calls.generic_message_pb2 import MessageType
 from beams.service.remote_calls.heartbeat_pb2 import HeartBeatReply
 from beams.service.rpc_client import RPCClient
@@ -13,9 +13,21 @@ def assert_heartbeat_has_n_trees(client: RPCClient, n_entries) -> bool:
     return len(resp1.behavior_tree_update) == n_entries
 
 
-def assert_valid_tick_status_at_idx(client: RPCClient, tree_idx: int):
+def assert_valid_tick_status_at_idx(client: RPCClient, tree_idx: int) -> bool:
     curr_status = client.get_heartbeat().behavior_tree_update[tree_idx].tick_status
     return curr_status != TickStatus.INVALID
+
+
+def assert_test_status(rpc_client: RPCClient, name: str, status: TreeStatus) -> bool:
+    resp = rpc_client.get_heartbeat()
+    my_msg = None
+    for update_msg in resp.behavior_tree_update:
+        if update_msg.tree_name == name:
+            my_msg = update_msg
+
+    if my_msg is None:
+        return False
+    return my_msg.tree_status == status
 
 
 def test_heartbeat(rpc_client: RPCClient):
@@ -46,6 +58,9 @@ def test_load_run_continuous_tree(rpc_client: RPCClient):
     assert resp1.behavior_tree_update[0].tree_name == "Eternal Guard"
     wait_until(partial(assert_valid_tick_status_at_idx, rpc_client, 0))
 
+    wait_until(partial(assert_test_status,
+                       rpc_client, "Eternal Guard", TreeStatus.TICKING))
+
 
 def test_load_interactive_tree(rpc_client: RPCClient):
     tree_path = Path(__file__).parent / "artifacts" / "eternal_guard.json"
@@ -64,7 +79,28 @@ def test_load_interactive_tree(rpc_client: RPCClient):
     wait_until(partial(assert_heartbeat_has_n_trees, rpc_client, 1))
     resp0 = rpc_client.get_heartbeat()
     assert resp0.behavior_tree_update[0].tick_status == TickStatus.INVALID
+    wait_until(partial(assert_test_status,
+                       rpc_client, "Eternal Guard", TreeStatus.WAITING_ACK))
 
     # tick tree
     rpc_client.tick_tree("my_tree")
     wait_until(partial(assert_valid_tick_status_at_idx, rpc_client, 0))
+
+    # back to waiting for tick
+    wait_until(partial(assert_test_status,
+                       rpc_client, "Eternal Guard", TreeStatus.WAITING_ACK))
+
+
+def test_pause_tree(rpc_client: RPCClient):
+    tree_path = Path(__file__).parent / "artifacts" / "eternal_guard.json"
+    rpc_client.load_new_tree(
+        new_tree_filepath=str(tree_path),
+        tick_config="INTERACTIVE",
+        tick_delay_ms=10,
+        tree_name="my_tree"
+    )
+
+    wait_until(partial(assert_test_status, rpc_client, "Eternal Guard", TreeStatus.IDLE))
+
+    rpc_client.start_tree("my_tree")
+    wait_until(partial(assert_test_status, rpc_client, "Eternal Guard", TreeStatus.TICKING))

--- a/docs/source/upcoming_release_notes/99-mnt_paused_heartbeat.rst
+++ b/docs/source/upcoming_release_notes/99-mnt_paused_heartbeat.rst
@@ -1,0 +1,27 @@
+99 mnt_paused_heartbeat
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds a TreeStatus enum to be delivered in the BehaviorTreeUpdateMessages, which reports the meta status of the tree as one of:
+
+  - `IDLE`
+  - `RUNNING`
+  - `WAITING_ACK`
+  - `ERROR`
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Adds a `TreeStatus` enum to be delivered in the `BehaviorTreeUpdateMessage`s, which reports the meta status of the tree as one of:
* IDLE
* RUNNING
* WAITING_ACK
* ERROR

This is distinct from the tick status, as any one of these tree statuses can be combined with any tick status (an IDLE tree can have a root node that reports success/failure/running, as can a RUNNING tree etc)


## Motivation and Context
I want to be able to represent this information in GUI applications.  Closes #95 

More directly, once you pause a tree, there's no way to find out what trees are paused or running based on the heartbeat message.  

## How Has This Been Tested?
Tests have been added, and existing tests have been augmented.

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
