### PR TITLE
ENH: basic node editor functionality

### DIFF
--- a/beams/bin/main.py
+++ b/beams/bin/main.py
@@ -20,6 +20,7 @@ COMMAND_TO_MODULE = {
     "gen_test_ioc": "gen_test_ioc",
     "service" : "service",
     "client": "client",
+    "ui": "ui"
 }
 
 

--- a/beams/bin/ui.py
+++ b/beams/bin/ui.py
@@ -1,0 +1,24 @@
+"""
+Open the BEAMS graphical user interace.  (Very work in progress)
+"""
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+
+def main(*args, **kwargs):
+    from beams.bin.ui_main import main
+    main(*args, **kwargs)

--- a/beams/bin/ui_main.py
+++ b/beams/bin/ui_main.py
@@ -13,7 +13,7 @@ def main(*args, **kwargs):
     my_style.node.layout_direction = LayoutDirection.VERTICAL
 
     add_items_to_registry(registry, style=my_style)
-    registry.register_model(RootNodeModel, style=my_style)
+    registry.register_model(RootNodeModel, style=my_style, category="Root")
     scene = nodeeditor.FlowScene(style=my_style, registry=registry)
 
     view = nodeeditor.FlowView(scene)

--- a/beams/bin/ui_main.py
+++ b/beams/bin/ui_main.py
@@ -1,6 +1,6 @@
 import qtpynodeeditor as nodeeditor
 from qtpy.QtWidgets import QApplication
-from qtpynodeeditor.node_geometry import LayoutDirection
+from qtpynodeeditor.style import LayoutDirection, SplineType
 
 from beams.widgets.models import RootNodeModel, add_items_to_registry
 
@@ -11,6 +11,7 @@ def main(*args, **kwargs):
 
     my_style = nodeeditor.StyleCollection()
     my_style.node.layout_direction = LayoutDirection.VERTICAL
+    my_style.connection.spline_type = SplineType.LINEAR
 
     add_items_to_registry(registry, style=my_style)
     registry.register_model(RootNodeModel, style=my_style, category="Root")

--- a/beams/bin/ui_main.py
+++ b/beams/bin/ui_main.py
@@ -1,0 +1,24 @@
+import qtpynodeeditor as nodeeditor
+from qtpy.QtWidgets import QApplication
+from qtpynodeeditor.node_geometry import LayoutDirection
+
+from beams.widgets.models import RootNodeModel, add_items_to_registry
+
+
+def main(*args, **kwargs):
+    app = QApplication([])
+    registry = nodeeditor.DataModelRegistry()
+
+    my_style = nodeeditor.StyleCollection()
+    my_style.node.layout_direction = LayoutDirection.VERTICAL
+
+    add_items_to_registry(registry, style=my_style)
+    registry.register_model(RootNodeModel, style=my_style)
+    scene = nodeeditor.FlowScene(style=my_style, registry=registry)
+
+    view = nodeeditor.FlowView(scene)
+    view.setWindowTitle("Beams Behavior Tree Builder")
+    view.resize(800, 600)
+    view.show()
+
+    app.exec_()

--- a/beams/tests/test_bin.py
+++ b/beams/tests/test_bin.py
@@ -22,7 +22,7 @@ from beams.tree_config.value import EPICSValue
 
 logger = logging.getLogger(__name__)
 
-SUBCOMMANDS = ["", "run", "gen_test_ioc", "service", "validate", "client"]
+SUBCOMMANDS = ["", "run", "gen_test_ioc", "service", "validate", "client", "ui"]
 
 
 def arg_variants(variants: tuple[tuple[tuple[str]]]):

--- a/beams/tree_config/action.py
+++ b/beams/tree_config/action.py
@@ -94,3 +94,10 @@ class IncPVActionItem(BaseItem):
         )
 
         return node
+
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    SetPVActionItem,
+    IncPVActionItem,
+]

--- a/beams/tree_config/composite.py
+++ b/beams/tree_config/composite.py
@@ -105,3 +105,12 @@ class SequenceConditionItem(BaseSequenceItem, BaseConditionItem):
             return ok
 
         return cond_func
+
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    ParallelItem,
+    SelectorItem,
+    SequenceItem,
+    SequenceConditionItem,
+]

--- a/beams/tree_config/condition.py
+++ b/beams/tree_config/condition.py
@@ -66,7 +66,7 @@ class BinaryConditionItem(BaseConditionItem):
 
 @dataclass
 class BoundedConditionItem(BaseConditionItem):
-    # TODO: convinience members such as "symettric bounds", "relative tolerance", etc
+    # TODO: convinience members such as "symetric bounds", "relative tolerance", etc
     lower_bound: BaseValue = field(default_factory=lambda: FixedValue(0))
     upper_bound: BaseValue = field(default_factory=lambda: FixedValue(0))
     value: BaseValue = field(default_factory=lambda: FixedValue(0))
@@ -84,3 +84,12 @@ class AcknowledgeConditionItem(BaseItem):
 
     def get_tree(self) -> AckConditionNode:
         return AckConditionNode(self.name, self.permisible_user_list)
+
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    DummyConditionItem,
+    BinaryConditionItem,
+    BoundedConditionItem,
+    AcknowledgeConditionItem,
+]

--- a/beams/tree_config/idiom.py
+++ b/beams/tree_config/idiom.py
@@ -50,3 +50,10 @@ class UseCheckConditionItem(BaseConditionItem):
     If used in any other context the tree will not be constructable.
     """
     ...
+
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    CheckAndDoItem,
+    UseCheckConditionItem,
+]

--- a/beams/tree_config/prebuilt/__init__.py
+++ b/beams/tree_config/prebuilt/__init__.py
@@ -1,0 +1,8 @@
+from beams.tree_config.prebuilt.reset_ioc import ResetIOCItem
+from beams.tree_config.prebuilt.wait_for_ack import WaitForAckNodeItem
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    ResetIOCItem,
+    WaitForAckNodeItem,
+]

--- a/beams/tree_config/py_trees.py
+++ b/beams/tree_config/py_trees.py
@@ -124,3 +124,24 @@ class WaitForBlackboardVariableValueItem(BaseItem):
             operator=getattr(operator, self.check.operator.value)
         )
         return WaitForBlackboardVariableValue(name=self.name, check=comp_exp)
+
+
+# Add items here if they should be made available in the GUI
+_supported_items = [
+    SuccessItem,
+    FailureItem,
+    RunningItem,
+    DummyItem,
+    PeriodicItem,
+    StatusQueueItem,
+    StatusQueueItem,
+    SuccessEveryNItem,
+    TickCounterItem,
+    BlackboardToStatusItem,
+    CheckBlackboardVariableExistsItem,
+    WaitForBlackboardVariableItem,
+    UnsetBlackboardVariableItem,
+    SetBlackboardVariableItem,
+    CheckBlackboardVariableValueItem,
+    WaitForBlackboardVariableValueItem,
+]

--- a/beams/widgets/action.py
+++ b/beams/widgets/action.py
@@ -1,0 +1,29 @@
+"""
+Widgets for node items from beams.tree_config.action
+"""
+
+from qtpy import QtWidgets
+
+from beams.tree_config.action import SetPVActionItem
+from beams.widgets.base import EmbeddedNodeWidget
+
+
+class SetPVActionWidget(EmbeddedNodeWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.form_layout = QtWidgets.QFormLayout()
+        self.setLayout(self.form_layout)
+
+        self.pv_edit = QtWidgets.QLineEdit()
+        self.form_layout.addRow("EPICS PV:", self.pv_edit)
+        self.value_edit = QtWidgets.QLineEdit()
+        self.form_layout.addRow("Value:", self.value_edit)
+
+        self.loop_period_edit = QtWidgets.QDoubleSpinBox()
+        self.form_layout.addRow("Loop Period:", self.loop_period_edit)
+
+    def update_item(self, item: SetPVActionItem):
+        item.pv = self.pv_edit.text()
+        item.value = self.value_edit.text()  # TODO: deal with types
+        item.loop_period_sec = self.loop_period_edit.value()

--- a/beams/widgets/base.py
+++ b/beams/widgets/base.py
@@ -1,0 +1,63 @@
+"""
+Base class for embedded widgets and helper for gathering embedded widgets
+
+Custom embedded widgets should be placed in submodules here with names matching
+their item.
+
+Example:
+
+beams.tree_config.action.SetPVActionItem -> beams.widgets.action.SetPVActionWidget
+"""
+
+import importlib
+from typing import Optional, Type
+
+from qtpy import QtWidgets
+
+from beams.tree_config.base import BaseItem
+
+
+class EmbeddedNodeWidget(QtWidgets.QWidget):
+    """
+    Base class for a widget displayed inside a tree node.
+    Should be a small widget, with very basic entry fields.
+
+    Must implement the update_data for the corresponding dataclass
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def update_data(self, item: BaseItem) -> None:
+        """
+        Update `item` with information from this widget.
+        To be implemented in the subclass
+        """
+        raise NotImplementedError
+
+
+def get_embedded_widget(item_cls: Type[BaseItem]) -> Optional[Type[EmbeddedNodeWidget]]:
+    """
+    Get the embedded widget corresponding to `item_cls`.
+    Search in the submodule of beams.widgets that matches the module `item_cls`
+    is from for a widget with the same base name as `item_cls`
+
+    Parameters
+    ----------
+    item_cls : Type[BaseItem]
+        The item dataclass to find a widget for
+
+    Returns
+    -------
+    Optional[Type[EmbeddedNodeWidget]]
+        The corresponding widget, or None if one cannot be found
+    """
+    try:
+        item_module_name = item_cls.__module__.split(".")[-1]
+        item_base_name = item_cls.__name__.removesuffix("Item")
+        mod = importlib.import_module(f"beams.widgets.{item_module_name}")
+        widget = getattr(mod, f"{item_base_name}Widget")
+    except (ModuleNotFoundError, AttributeError) as ex:
+        print(ex)
+        return
+
+    return widget

--- a/beams/widgets/base.py
+++ b/beams/widgets/base.py
@@ -10,11 +10,14 @@ beams.tree_config.action.SetPVActionItem -> beams.widgets.action.SetPVActionWidg
 """
 
 import importlib
+import logging
 from typing import Optional, Type
 
 from qtpy import QtWidgets
 
 from beams.tree_config.base import BaseItem
+
+logger = logging.getLogger(__name__)
 
 
 class EmbeddedNodeWidget(QtWidgets.QWidget):
@@ -56,8 +59,8 @@ def get_embedded_widget(item_cls: Type[BaseItem]) -> Optional[Type[EmbeddedNodeW
         item_base_name = item_cls.__name__.removesuffix("Item")
         mod = importlib.import_module(f"beams.widgets.{item_module_name}")
         widget = getattr(mod, f"{item_base_name}Widget")
-    except (ModuleNotFoundError, AttributeError) as ex:
-        print(ex)
+    except (ModuleNotFoundError, AttributeError):
+        logger.debug(f"No embedded widget found for {item_base_name}")
         return
 
     return widget

--- a/beams/widgets/base.py
+++ b/beams/widgets/base.py
@@ -35,9 +35,6 @@ class EmbeddedNodeWidget(QtWidgets.QWidget):
 
     Must implement the update_data for the corresponding dataclass
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def update_data(self, item: BaseItem) -> None:
         """
         Update `item` with information from this widget.

--- a/beams/widgets/base.py
+++ b/beams/widgets/base.py
@@ -7,6 +7,14 @@ their item.
 Example:
 
 beams.tree_config.action.SetPVActionItem -> beams.widgets.action.SetPVActionWidget
+
+The `get_embedded_widget` function is meant to be called by `TreeNodeMixin` when
+tree node models are programmatically generated, so that widgets are automatically
+added to the right nodes.
+
+Thus, when making new node widgets, you should not have to worry about the
+qtpynodeeditor NodeDataModel details.  Rather one simply needs to subclass
+EmbeddedNodeWidget and name it correctly.
 """
 
 import importlib

--- a/beams/widgets/models.py
+++ b/beams/widgets/models.py
@@ -48,7 +48,14 @@ class RootNodeModel(NodeDataModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._output_connections = []
-        self.update_validation()
+        self._validation_state = NodeValidationState.warning
+        self._validation_message = "No children connected"
+
+    def validation_state(self) -> NodeValidationState:
+        return self._validation_state
+
+    def validation_message(self) -> str:
+        return self._validation_message
 
     def output_connection_created(self, connection: Connection):
         """Triggered from `FlowScene` when a connection is created"""

--- a/beams/widgets/models.py
+++ b/beams/widgets/models.py
@@ -258,7 +258,8 @@ def add_items_to_registry(
     submodules: Optional[list[str]] = None,
 ):
     if submodules is None:
-        submodules = ["action", "composite", "condition", "idiom", "py_trees"]
+        submodules = ["action", "composite", "condition", "idiom", "py_trees",
+                      "prebuilt"]
 
     for submod in submodules:
         models = gather_models(submod)

--- a/beams/widgets/models.py
+++ b/beams/widgets/models.py
@@ -1,0 +1,266 @@
+"""
+qtpynodeeditor data types for ui representations of Behavior Trees
+
+These do not contain any logic related to actually ticking/running trees,
+rather any connections that are made are only for validation and saving trees.
+
+NodeData = edges
+NodeDataModel = nodes
+"""
+import importlib
+from typing import Optional, Sequence, Type
+
+import qtpynodeeditor as nodeeditor
+from qtpy.QtWidgets import QWidget
+from qtpynodeeditor import (Connection, NodeData, NodeDataModel, NodeDataType,
+                            NodeValidationState, Port)
+from qtpynodeeditor.style import StyleCollection
+
+from beams.tree_config import BaseItem
+from beams.widgets.base import get_embedded_widget
+
+
+class BlankNodeData(NodeData):
+    """
+    Node data with no caption.  We don't actually pass data between nodes,
+    so there's no need to label the ports
+    """
+    # port caption defaults to node data type if there's no caption provided
+    # add some spaces to help with spacing
+    data_type = NodeDataType("n/a", "  ")
+
+
+class RootNodeModel(NodeDataModel):
+    """
+    Root node model.  Simply holds one child node
+    Is valid if it has a child
+    """
+    caption_visible = True
+    num_ports = {"input": 0, "output": 1}
+    port_caption_visible = {
+        "input": {},
+        "output": {0: False},
+    }
+    data_type = BlankNodeData.data_type
+    name = " Root "
+
+    def set_out_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the parent node is a valid predecessor
+        # self._parent_node = node_data.parent_node
+        try:
+            self._child_node = port.connections[0].output_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+
+class MultiChildNodeModel(NodeDataModel):
+    """
+    Mixin class holding logic to enable dynamic number of children.
+    This requires making .num_ports, .data_type, and .port_caption_visible
+    react to the number of connections.
+
+    num_ports is a property to avoid the validation performed by NodeDataModel
+
+    Takes no children, and is valid if it has a parent
+    """
+    def __init__(self, style=None, parent=None, max_children: int = 0):
+        super().__init__(style=style, parent=parent)
+        self.caption_visible = True
+        self.max_children = max_children
+        # initial ports
+        self._num_ports = {"input": 1, "output": 1}
+        self._port_caption_visible = {
+            "input": {0: False},
+            "output": {0: False},
+        }
+        # for multiple ouptuts, must provide a dictionary
+        # NodeDataModel tries to fill sensible default dictionaries, but gives up
+        # if num_ports is a property (if dynamically defined)
+        self._data_type = {
+            "input": {0: BlankNodeData.data_type},
+            "output": {0: BlankNodeData.data_type},
+        }
+
+        self._parent_node = None
+        self._validation_state = NodeValidationState.warning
+        self._validation_message = "Uninitialized"
+
+        self.output_connections = []
+
+    @property
+    def caption(self):
+        return self.name
+
+    def validation_state(self) -> NodeValidationState:
+        return self._validation_state
+
+    def validation_message(self) -> str:
+        return self._validation_message
+
+    def set_in_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the parent node is a valid predecessor
+        # self._parent_node = node_data.parent_node
+        try:
+            self._parent_node = port.connections[0].input_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+    @property
+    def num_ports(self):
+        return self._num_ports
+
+    @property
+    def data_type(self):
+        return self._data_type
+
+    @property
+    def port_caption_visible(self):
+        return self._port_caption_visible
+
+    def output_connection_created(self, connection: Connection):
+        # triggered from FlowScene when connection created.
+        # want to add a new node
+        if connection in self.output_connections:
+            return
+        self.output_connections.append(connection)
+        self._update_output_info()
+
+    def output_connection_deleted(self, connection):
+        # need to take all existing connections and re-order them
+        if connection not in self.output_connections:
+            return
+        self.output_connections.remove(connection)
+        self._update_output_info()
+
+    def _update_output_info(self):
+        if self.max_children > 0:
+            num_new_conn = min(len(self.output_connections) + 1,
+                               self.max_children)
+        else:
+            num_new_conn = len(self.output_connections) + 1
+
+        self._num_ports["output"] = num_new_conn
+        self._port_caption_visible["output"] = {
+            i: False for i in range(num_new_conn)
+        }
+        self._data_type["output"] = {
+            i: BlankNodeData.data_type for i in range(num_new_conn)
+        }
+
+
+class LeafNodeModel(NodeDataModel):
+    """
+    NodeModel mixin for leaf nodes (action nodes)
+    Takes no children, and is valid if it has a parent
+    """
+    caption_visible = True
+    num_ports = {"input": 1, "output": 0}
+    port_caption_visible = {
+        "input": {0: False},
+        "output": {}
+    }
+    data_type = BlankNodeData.data_type
+
+    def __init__(self, style=None, parent=None):
+        super().__init__(style=style, parent=parent)
+        self._parent_node = None
+        self._validation_state = NodeValidationState.warning
+        self._validation_message = "Uninitialized"
+
+    def __init_subclass__(cls, verify=True, **kwargs):
+        return super().__init_subclass__(verify, **kwargs)
+
+    @property
+    def caption(self):
+        return self.name
+
+    def set_in_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the parent node is a valid predecessor
+        # self._parent_node = node_data.parent_node
+        try:
+            self._parent_node = port.connections[0].input_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+    def validation_state(self) -> NodeValidationState:
+        return self._validation_state
+
+    def validation_message(self) -> str:
+        return self._validation_message
+
+
+class TreeNodeMixin:
+    """
+    Mixin that supplies functionality for storing behavior tree item
+    objects and retrieving them.
+
+    To be mixed in with a NodeModel of some sort... maybe?
+    """
+    item_cls: Type[BaseItem]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.item = self.item_cls()
+        self._widget_cls = get_embedded_widget(self.item_cls)
+        if self._widget_cls:
+            self._widget = self._widget_cls()
+        else:
+            self._widget = None
+
+    def get_item(self):
+        if self._widget:
+            self._widget.update_data(self.item)
+        return self.item
+
+    def embedded_widget(self) -> Optional[QWidget]:
+        """Fetch a QWidget"""
+        return self._widget
+
+
+def gather_models(submodule: str) -> Sequence[TreeNodeMixin]:
+    """
+    Gather and add all available models to the ``scene``
+    Organize them by their submodule name
+    """
+    models = []
+    mod = importlib.import_module(f"beams.tree_config.{submodule}")
+    items = getattr(mod, "_supported_items")
+    # Create a class mixing TreeNodeMixin + (appropiate Leaf/Parent)
+    # also assign the right item class and name for the registry
+    for item in items:
+        name = str(item.__name__).removesuffix("Item")
+        if hasattr(item(), "children"):
+            node_model_cls = MultiChildNodeModel
+        else:
+            node_model_cls = LeafNodeModel
+
+        model_cls = type(
+            f"{name}Model", (TreeNodeMixin, node_model_cls),
+            {"item_cls": item, "name": name})
+
+        models.append(model_cls)
+
+    return models
+
+
+def add_items_to_registry(
+    registry: nodeeditor.DataModelRegistry,
+    style: StyleCollection,
+    submodules: Optional[list[str]] = None,
+):
+    if submodules is None:
+        submodules = ["action", "composite", "condition", "idiom", "py_trees"]
+
+    for submod in submodules:
+        models = gather_models(submod)
+        for model in models:
+            registry.register_model(model, category=submod, style=style)

--- a/docs/source/upcoming_release_notes/100-enh_basic_nodes.rst
+++ b/docs/source/upcoming_release_notes/100-enh_basic_nodes.rst
@@ -1,0 +1,24 @@
+100 enh_basic_nodes
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds basic framework for setting up a node editor that features BEAMS node types
+- Sets up systems for automatically creating node classes for each behavior tree node (BaseItem)
+- Sets up a system for creating and collecting embedded widgets for these modes
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adds pcdshub/qtpynodeeditor as a dependency
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ grpcio-tools
 jinja2
 py-trees
 pyepics
-pygraphviz
 pyyaml
 qtpynodeeditor @ git+https://github.com/pcdshub/qtpynodeeditor.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ grpcio-tools
 jinja2
 py-trees
 pyepics
+pygraphviz
 pyyaml
 qtpynodeeditor @ git+https://github.com/pcdshub/qtpynodeeditor.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jinja2
 py-trees
 pyepics
 pyyaml
+qtpynodeeditor @ git+https://github.com/pcdshub/qtpynodeeditor.git@master


### PR DESCRIPTION
## Description
- Adds basic framework for setting up a node editor that features BEAMS node types
- Sets up systems for automatically creating node classes for each behavior tree node (BaseItem)
- Sets up a system for creating and collecting embedded widgets for these modes
- Adds pcdshub/qtpynodeeditor as a dependency

TODO:
- [ ] ~~Build a slightly more fully featured ui with auto-arrange buttons?~~  (Deferred)
- [ ] ~~build ability to extract constructed BehaviorTree from the graphical representation (possibly from digraph?)~~ (Deferred)

## Motivation and Context
We dream of being able to create a tree in the BEAMS gui, and this is our first steps toward this

Much of the ui finessing should probably be done in the qtpynodeeditor side.  I'm working on that in parallel

### Organization
Lacking a better system, we do a bit of pattern matching between the tree_config submodule.  We gather all the `_supported_items` from the various submodules, and create a NodeDataModel using the appropriate mixin classes.

We do similar pattern matching on the embedded widget side.  Every embedded widget must be in a submodule that shares a name with the `BaseItem` it's representing, and be named `<ItemName>Widget`. 

I've added an example to help illustrate how this all works, but maybe there's a better way that I gave up looking for. 

## How Has This Been Tested?
Interactively.  Lord spare me from gui testing (for now)

## Where Has This Been Documented?
This PR

Example of something created after running "beams ui"
<img width="544" alt="image" src="https://github.com/user-attachments/assets/517cf46a-59c2-4129-8d0e-b51f3e055ac8" />

right-click gives you a node selector
<img width="279" alt="image" src="https://github.com/user-attachments/assets/a943983f-ffb5-49e5-9992-117e6ee1a80b" />

A gathered embedded widget
<img width="365" alt="image" src="https://github.com/user-attachments/assets/d6609cd3-1e41-4458-afaf-159d31d8f4af" />



## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
