### PR TITLE
FIX: disable ecs shared dotfiles http config that breaks beams

### DIFF
--- a/beams/service/rpc_client.py
+++ b/beams/service/rpc_client.py
@@ -223,7 +223,11 @@ class RPCClient:
 
             if stub is None:
                 # TODO: obviously not this. Grab from config
-                with grpc.insecure_channel(self.server_address) as channel:
+                with grpc.insecure_channel(
+                    self.server_address,
+                    # Default ecs config uses psproxy, which doesn't work here
+                    options=(("grpc.enable_http_proxy", 0),)
+                ) as channel:
                     stub = BEAMS_rpcStub(channel)
                     return func(self, stub=stub, *args, **kwargs)
             else:

--- a/docs/source/upcoming_release_notes/106-fix_disable_http_proxy.rst
+++ b/docs/source/upcoming_release_notes/106-fix_disable_http_proxy.rst
@@ -1,0 +1,22 @@
+106 fix_disable_http_proxy
+##########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Ignore local http_proxy settings intended for connecting to the internet outside of SLAC.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
HTTP proxy setting send beams commands to psproxy instead of to the desired server. This PR disables HTTP proxies for the BEAMS client.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The http proxies set here
https://github.com/pcdshub/shared-dotfiles/blob/2f38a40712bdade5ffd9892a89b4c2451625cc67/on_site/bashrc#L214-L215
break beams

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively by making sure we can use the beams client using a prod bashrc

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only and in pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
