### PR TITLE
FIX: small syntax fix in getting correct client method from cli

### DIFF
--- a/beams/service/rpc_client.py
+++ b/beams/service/rpc_client.py
@@ -172,7 +172,7 @@ class RPCClient:
         tree_name = kwargs.get("tree_name") or ""
         # These commands only need captured tree name and command itself
         if command in self.BASE_COMMANDS:
-            getattr(self, f"_{CommandType.Name(command).lower()}")(tree_name)
+            getattr(self, f"{CommandType.Name(command).lower()}")(tree_name)
         elif command == CommandType.LOAD_NEW_TREE:
             self.load_new_tree(
                 tree_name=tree_name,

--- a/docs/source/upcoming_release_notes/107-client-cli-fix.rst
+++ b/docs/source/upcoming_release_notes/107-client-cli-fix.rst
@@ -1,0 +1,22 @@
+1 eggs
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+In beams/service/rpc_client.py we were faultily appending an `_` when searching for member tasks. This didn't get you when you were testing via shell and instantiating the class, but it does when you are purely using the cli interface.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Very small client CLI bug that snuck in. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Old bug reproduced through spawning a tree and trying to start it. 
![image](https://github.com/user-attachments/assets/55e33f78-827c-4c1f-8983-7b90e3471296)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
