### PR TITLE
ENH: add detailed `TreeDetails` proto, identify trees and nodes by uuid

### DIFF
--- a/beams/bin/service_main.py
+++ b/beams/bin/service_main.py
@@ -96,7 +96,7 @@ class BeamsService(Worker):
         with self.sync_man as man:
             # get tree
             tree_dict = man.get_tree_dict()
-            tree_ticker = get_tree_from_treetickerdict(
+            _, tree_ticker = get_tree_from_treetickerdict(
                 tree_dict, name=request.tree_name, uuid=request.tree_uuid,
             )
             if tree_ticker is not None:
@@ -106,7 +106,7 @@ class BeamsService(Worker):
         with self.sync_man as man:
             # get tree
             tree_dict = man.get_tree_dict()
-            tree_ticker = get_tree_from_treetickerdict(
+            _, tree_ticker = get_tree_from_treetickerdict(
                 tree_dict, name=request.tree_name, uuid=request.tree_uuid,
             )
             if tree_ticker is not None:
@@ -116,7 +116,7 @@ class BeamsService(Worker):
         with self.sync_man as man:
             # get tree
             tree_dict = man.get_tree_dict()
-            tree_ticker = get_tree_from_treetickerdict(
+            _, tree_ticker = get_tree_from_treetickerdict(
                 tree_dict, name=request.tree_name, uuid=request.tree_uuid,
             )
             if tree_ticker is not None:
@@ -127,7 +127,7 @@ class BeamsService(Worker):
         user_acking_node = request.ack_node.user_acking_node
         with self.sync_man as man:
             tree_dict = man.get_tree_dict()
-            tree_ticker = get_tree_from_treetickerdict(
+            _, tree_ticker = get_tree_from_treetickerdict(
                 tree_dict, name=request.tree_name, uuid=request.tree_uuid,
             )
             if tree_ticker is not None:

--- a/beams/bin/service_main.py
+++ b/beams/bin/service_main.py
@@ -84,7 +84,6 @@ class BeamsService(Worker):
             x = man.TreeTicker(filepath=request.load_new_tree.tree_file_path,
                                init_tree_state=init_state)
             tree_dict = man.get_tree_dict()
-            print(type(tree_dict))
 
             # New trees won't have uuids, but likely have names
             tree_id = TreeIdKey(name=request.tree_name)

--- a/beams/service/remote_calls/beams_rpc.proto
+++ b/beams/service/remote_calls/beams_rpc.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "beams/service/remote_calls/generic_message.proto"; // Empty
 import "beams/service/remote_calls/heartbeat.proto"; // HeartBeatReply
 import "beams/service/remote_calls/command.proto"; // CommandMessage
+import "beams/service/remote_calls/behavior_tree.proto";
 
 // Sequencer Service Definition
 service BEAMS_rpc {
@@ -11,4 +12,7 @@ service BEAMS_rpc {
 
   // Heart beat message for clients
   rpc request_heartbeat (Empty) returns (HeartBeatReply) {}
+
+  // Detailed message for clients
+  rpc request_tree_details (NodeId) returns (TreeDetails) {}
 }

--- a/beams/service/remote_calls/behavior_tree.proto
+++ b/beams/service/remote_calls/behavior_tree.proto
@@ -25,12 +25,30 @@ enum TreeStatus {
   ERROR = 3;
 }
 
+// identification information for a node
+message NodeId {
+  string name = 1;
+  string uuid = 2;
+}
+
 message BehaviorTreeUpdateMessage {
   MessageType mess_t = 1; // MESSAGE_TYPE_BEHAVIOR_TREE_MESSAGE
-  string tree_name = 2;
-  string node_name = 3;
+  NodeId tree_id = 2;
+  NodeId node_id = 3;
   TickStatus tick_status = 4;
-  TickConfiguration tick_config= 5;
+  TickConfiguration tick_config = 5;
   int32 tick_delay_ms = 6;
   TreeStatus tree_status = 7;
+}
+
+message NodeInfo {
+  NodeId id = 1;
+  TickStatus status = 2;
+  repeated NodeInfo children = 3;
+}
+
+message TreeDetails {
+  NodeId tree_id = 1;
+  NodeInfo node_info = 2;
+  TreeStatus tree_status = 3;
 }

--- a/beams/service/remote_calls/command.proto
+++ b/beams/service/remote_calls/command.proto
@@ -44,9 +44,13 @@ message CommandMessage {
   MessageType mess_t = 1; // MESSAGE_TYPE_COMMAND_MESSAGE
   CommandType command_t = 2; // informs which option to try deser
   // May want to add notion of priority here
+
+  // Can specify which tree to act on with either name or uuid
   string tree_name = 3;
-  optional int32 tick_rate_ms = 4;
-  optional AckNodeMessage ack_node = 5;
-  optional LoadNewTreeMessage load_new_tree = 6;
-  optional TickConfigurationMessage tick_config = 7;
+  string tree_uuid = 4;
+
+  optional int32 tick_rate_ms = 5;
+  optional AckNodeMessage ack_node = 6;
+  optional LoadNewTreeMessage load_new_tree = 7;
+  optional TickConfigurationMessage tick_config = 8;
 }

--- a/beams/service/remote_calls/heartbeat.proto
+++ b/beams/service/remote_calls/heartbeat.proto
@@ -12,7 +12,8 @@ import "beams/service/remote_calls/behavior_tree.proto";
 
 message HeartBeatReply {
   MessageType mess_t = 1;
-  repeated BehaviorTreeUpdateMessage behavior_tree_update = 2; // when our program is ticking many trees this may become a repeated or mapped fields
+  // when our program is ticking many trees this may become a repeated or mapped fields
+  repeated BehaviorTreeUpdateMessage behavior_tree_update = 2;
   google.protobuf.Timestamp reply_timestamp = 3;
   // maybe program uptime and git hash??
 }

--- a/beams/service/rpc_client.py
+++ b/beams/service/rpc_client.py
@@ -438,30 +438,33 @@ class RPCClient:
     def get_detailed_update(
         self,
         tree_name: Optional[str] = None,
-        tree_uuid: Optional[Union[UUID, str]] = None,
+        tree_uuid: Optional[Union[UUID, str]] = "",
         stub: Optional[BEAMS_rpcStub] = None,
     ) -> TreeDetails:
         """
         Gets a detailed update for a tree from the service.
         Trees can be identified by either their name or uuid, but at least one
-        of these must be provided
+        of these must be provided.
 
         If the uuid is provided, the tree name is ignored.
 
         Parameters
         ----------
         tree_name : Optional[str]
-            _description_
+            The name of the tree in question
         tree_uuid : Optional[Union[UUID, str]]
-            _description_
+            The uuid of the tree in question.  May be a partial uuid (>= 5 characters)
         stub : Optional[BEAMS_rpcStub], optional
-            _description_, by default None
+            the rpc stub used to send messages, by default None
 
         Returns
         -------
         TreeDetails
-            _description_
+            a detailed view of the tree
         """
+        if not (tree_name or tree_uuid):
+            raise ValueError("Must provide either tree_name or tree_uuid")
+
         tree_id = NodeId(name=tree_name, uuid=str(tree_uuid))
         if stub is None:
             # TODO: obviously not this. Grab from config

--- a/beams/service/rpc_handler.py
+++ b/beams/service/rpc_handler.py
@@ -51,7 +51,6 @@ class TreeIdKey:
             else:
                 uuid_match = False
             name_match = (self.name == other)
-            print(uuid_match, name_match)
             return uuid_match or name_match
         elif isinstance(other, UUID):
             return self.uuid == other
@@ -155,7 +154,6 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
 
                 )]
             else:
-                print(key, tree_ticker)
                 logger.error(f"Unable to find tree of name {tree_name} currently being ticked")
                 return None
 

--- a/beams/service/rpc_handler.py
+++ b/beams/service/rpc_handler.py
@@ -137,9 +137,9 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         self,
         tree_name: Optional[str] = None,
         tree_uuid: Optional[Union[UUID, str]] = None,
-    ) -> Optional[List[BehaviorTreeUpdateMessage]]:
+    ) -> List[BehaviorTreeUpdateMessage]:
         if self.sync_man is None:  # for testing modularity
-            return None
+            return []
         with self.sync_man as man:
             tree_dict: TreeTickerDict = man.get_tree_dict()
             key, tree_ticker = get_tree_from_treetickerdict(
@@ -160,17 +160,17 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
                 )]
             else:
                 logger.error(f"Unable to find tree of name {tree_name} currently being ticked")
-                return None
+                return []
 
-    def get_all_tree_updates(self) -> Optional[List[BehaviorTreeUpdateMessage]]:
+    def get_all_tree_updates(self) -> List[BehaviorTreeUpdateMessage]:
         if self.sync_man is None:  # for testing modularity
-            return None
+            return []
 
         with self.sync_man as man:
             tree_dict: TreeTickerDict = man.get_tree_dict()
             # if dictionary empty return none
             if len(tree_dict.items()) == 0:
-                return None
+                return []
 
             updates = []
             for key, tree_ticker in tree_dict.items():
@@ -204,11 +204,8 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         hbeat_message = HeartBeatReply(mess_t=MessageType.MESSAGE_TYPE_HEARTBEAT)
         hbeat_message.reply_timestamp.GetCurrentTime()
 
-        if bt_update is None:
-            return hbeat_message
-        else:
-            hbeat_message.behavior_tree_update.extend(bt_update)
-            return hbeat_message
+        hbeat_message.behavior_tree_update.extend(bt_update)
+        return hbeat_message
 
     def request_heartbeat(self, request, context) -> HeartBeatReply:
         # assumption that hitting this service endpoint means you want to know
@@ -222,11 +219,8 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         hbeat_message = HeartBeatReply(mess_t=MessageType.MESSAGE_TYPE_HEARTBEAT)
         hbeat_message.reply_timestamp.GetCurrentTime()
 
-        if updates is None:
-            return hbeat_message
-        else:
-            hbeat_message.behavior_tree_update.extend(updates)
-            return hbeat_message
+        hbeat_message.behavior_tree_update.extend(updates)
+        return hbeat_message
 
     def request_tree_details(self, request: NodeId, context) -> TreeDetails:
         """

--- a/beams/service/rpc_handler.py
+++ b/beams/service/rpc_handler.py
@@ -27,9 +27,14 @@ class TreeIdKey:
     """
     Tree ID information bundle.
 
-    Name exists for readability only, and all comparisons are made on the uuid.
+    Name exists for readability primarily, and comparisons are first made on
+    the uuid, then the name.
     Partial uuids (str) matching the beginning of an instance's uuid are
-    considered equal to the instance (for ease of matching)
+    considered equal to the instance (for ease of matching).
+
+    When used as a dictionary key, items can be accessed with either:
+    - a TreeIdKey with the correct UUID
+    - a matching UUID directly
 
     Note that this does not let you use partial strings to match dictionary keys
     via the `in` keyword, since __contains__ uses hashes
@@ -223,7 +228,7 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
             hbeat_message.behavior_tree_update.extend(updates)
             return hbeat_message
 
-    def request_tree_details(self, request: NodeId, context) -> Optional[TreeDetails]:
+    def request_tree_details(self, request: NodeId, context) -> TreeDetails:
         """
         Gather tree details for the node ID provided
 

--- a/beams/service/rpc_handler.py
+++ b/beams/service/rpc_handler.py
@@ -1,21 +1,95 @@
 import logging
 import time
 from concurrent import futures
+from dataclasses import dataclass, field
 from multiprocessing import Manager, Queue, Semaphore
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
+from uuid import UUID, uuid4
 
 import grpc
 
 from beams.service.helpers.worker import Worker
 from beams.service.remote_calls.beams_rpc_pb2_grpc import (
     BEAMS_rpcServicer, add_BEAMS_rpcServicer_to_server)
-from beams.service.remote_calls.behavior_tree_pb2 import \
-    BehaviorTreeUpdateMessage
+from beams.service.remote_calls.behavior_tree_pb2 import (
+    BehaviorTreeUpdateMessage, NodeId, TreeDetails)
+from beams.service.remote_calls.command_pb2 import CommandMessage
 from beams.service.remote_calls.generic_message_pb2 import MessageType
 from beams.service.remote_calls.heartbeat_pb2 import HeartBeatReply
 from beams.service.tree_ticker import TreeTicker
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TreeIdKey:
+    """
+    Tree ID information bundle.
+
+    Name exists for readability only, and all comparisons are made on the uuid.
+    Partial uuids (str) matching the beginning of an instance's uuid are
+    considered equal to the instance (for ease of matching)
+
+    Note that this does not let you use partial strings to match dictionary keys
+    via the `in` keyword, since __contains__ uses hashes
+    """
+    name: str
+    uuid: UUID = field(default_factory=uuid4)
+
+    def __hash__(self) -> int:
+        # allow quick lookups by specifying uuid
+        return hash(self.uuid)
+
+    def __eq__(self, other) -> bool:
+        # Require partial strings to be greater than 5 to avoid collisions
+        # Eventually maybe somebody does some stats to figure out what a good
+        # threshold is (birthday paradox)
+        if isinstance(other, str) and len(other) >= 5:
+            return str(self.uuid).startswith(other)
+        elif isinstance(other, UUID):
+            return self.uuid == other
+        elif isinstance(other, TreeIdKey):
+            return self.uuid == other.uuid
+        return False
+
+
+TreeTickerDict = Dict[TreeIdKey, TreeTicker]
+
+
+def get_tree_from_treetickerdict(
+    tree_dict: TreeTickerDict,
+    name: Optional[str] = None,
+    uuid: Optional[Union[UUID, str]] = None,
+) -> Optional[TreeTicker]:
+    """
+    Returns TreeTicker from `tree_dict` to best effort.
+    In order of priority:
+    1. Check for uuid full match
+    2. Check for uuid partial match
+    3. Check for tree name full match
+
+    Returns the first match it finds, in the case of collisions
+    Returns None if no match can be found
+    """
+    # `tree_dict` is often actually a multiprocessing.BaseProxy, which only exposes
+    # methods, not attributes (or subscripting).  Thus we use .get()
+    if not (name or uuid):
+        raise ValueError("One of `name` and `uuid` must be provided")
+
+    if isinstance(uuid, UUID):
+        return tree_dict.get(TreeIdKey(name="", uuid=uuid))
+    elif isinstance(uuid, str):
+        if len(uuid) < 5:
+            raise ValueError("Partial uuids must provide at least "
+                             f"5 characters, got ({uuid})")
+        for key in tree_dict.keys():
+            if key.uuid == uuid:
+                return tree_dict.get(key)
+
+    # no uuid matchees, try exact name match
+    for tree_id in tree_dict.keys():
+        if tree_id.name == name:
+            return tree_dict.get(tree_id)
 
 
 class RPCHandler(BEAMS_rpcServicer, Worker):
@@ -47,14 +121,20 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
     # NOTE: these could also live and work in a process spawned by beams service..
     # returns a single bt update as a list...
     def attempt_to_get_tree_update(
-        self, tree_name: str
+        self,
+        tree_name: Optional[str] = None,
+        tree_uuid: Optional[Union[UUID, str]] = None,
     ) -> Optional[List[BehaviorTreeUpdateMessage]]:
+        # TODO UUID SWAP
         if self.sync_man is None:  # for testing modularity
             return None
-        with self.sync_man as my_boy:
-            tree_dict: Dict[str, TreeTicker] = my_boy.get_tree_dict()
-            if tree_name in tree_dict.keys():
-                return [tree_dict.get(tree_name).get_behavior_tree_update()]
+        with self.sync_man as man:
+            tree_dict: TreeTickerDict = man.get_tree_dict()
+            tree_ticker = get_tree_from_treetickerdict(
+                tree_dict, name=tree_name, uuid=tree_uuid
+            )
+            if tree_ticker:
+                return [tree_ticker.get_behavior_tree_update()]
             else:
                 logger.error(f"Unable to find tree of name {tree_name} currently being ticked")
                 return None
@@ -63,17 +143,18 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         if self.sync_man is None:  # for testing modularity
             return None
 
-        with self.sync_man as your_boy:
-            tree_dict: Dict[str, TreeTicker] = your_boy.get_tree_dict()
+        with self.sync_man as man:
+            tree_dict: TreeTickerDict = man.get_tree_dict()
             # if dictionary empty return none
             if len(tree_dict.items()) == 0:
                 return None
 
-            updates = [tree.get_behavior_tree_update() for tree in tree_dict.values()]
+            updates = [tree.get_behavior_tree_update()
+                       for tree in tree_dict.values()]
 
             return updates
 
-    def enqueue_command(self, request, context) -> HeartBeatReply:
+    def enqueue_command(self, request: CommandMessage, context) -> HeartBeatReply:
         mess_t = request.mess_t
         if mess_t != MessageType.MESSAGE_TYPE_COMMAND_MESSAGE:
             logger.error("You seriously messed up, reevlauate your life choices")
@@ -112,6 +193,26 @@ class RPCHandler(BEAMS_rpcServicer, Worker):
         else:
             hbeat_message.behavior_tree_update.extend(updates)
             return hbeat_message
+
+    def request_tree_details(self, request: NodeId, context) -> TreeDetails:
+        """
+        Gather tree details for the node ID provided
+
+        Parameters
+        ----------
+        request : NodeId
+            The identification
+
+        Returns
+        -------
+        TreeDetails
+            The details of the requested tree
+        """
+        with self.sync_man as manager:
+            tree_dict: TreeTickerDict = manager.get_tree_dict()
+            tree_ticker = get_tree_from_treetickerdict(tree_dict, request.name, request.uuid)
+            if tree_ticker is not None:
+                return tree_ticker.get_detailed_update()
 
     def work_func(self):
         logger.debug(f"{self.proc_name} running")

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -256,8 +256,10 @@ class TreeTicker(Worker):
         return mess
 
     def get_detailed_update(self) -> TreeDetails:
-        dets = self.state.get_details()
-        return dets
+        det = self.state.get_details()
+        # update tick status, details only update after tick, not on pause
+        det.tree_status = self.state.get_tree_status()
+        return det
 
     def get_tree_details(self, tree: BehaviourTree) -> TreeDetails:
         """get the details for this tree in particular"""

--- a/beams/tests/test_rpc_handshakes.py
+++ b/beams/tests/test_rpc_handshakes.py
@@ -22,7 +22,7 @@ def assert_test_status(rpc_client: RPCClient, name: str, status: TreeStatus) -> 
     resp = rpc_client.get_heartbeat()
     my_msg = None
     for update_msg in resp.behavior_tree_update:
-        if update_msg.tree_name == name:
+        if update_msg.tree_id.name == name:
             my_msg = update_msg
 
     if my_msg is None:
@@ -56,7 +56,7 @@ def test_load_run_continuous_tree(rpc_client: RPCClient):
     wait_until(partial(assert_heartbeat_has_n_trees, rpc_client, 1))
     # tree name taken from json, not our setting
     resp1 = rpc_client.get_heartbeat()
-    assert resp1.behavior_tree_update[0].tree_name == "Eternal Guard"
+    assert resp1.behavior_tree_update[0].tree_id.name == "Eternal Guard"
     wait_until(partial(assert_valid_tick_status_at_idx, rpc_client, 0))
 
     wait_until(partial(assert_test_status,

--- a/beams/tests/test_rpc_handshakes.py
+++ b/beams/tests/test_rpc_handshakes.py
@@ -1,7 +1,9 @@
 from functools import partial
 from pathlib import Path
 
-from beams.service.remote_calls.behavior_tree_pb2 import TickStatus, TreeStatus
+from beams.service.remote_calls.behavior_tree_pb2 import (TickStatus,
+                                                          TreeDetails,
+                                                          TreeStatus)
 from beams.service.remote_calls.generic_message_pb2 import MessageType
 from beams.service.remote_calls.heartbeat_pb2 import HeartBeatReply
 from beams.service.rpc_client import RPCClient
@@ -56,11 +58,11 @@ def test_load_run_continuous_tree(rpc_client: RPCClient):
     wait_until(partial(assert_heartbeat_has_n_trees, rpc_client, 1))
     # tree name taken from json, not our setting
     resp1 = rpc_client.get_heartbeat()
-    assert resp1.behavior_tree_update[0].tree_id.name == "Eternal Guard"
+    assert resp1.behavior_tree_update[0].tree_id.name == "my_tree"
     wait_until(partial(assert_valid_tick_status_at_idx, rpc_client, 0))
 
     wait_until(partial(assert_test_status,
-                       rpc_client, "Eternal Guard", TreeStatus.TICKING))
+                       rpc_client, "my_tree", TreeStatus.TICKING))
 
 
 def test_load_interactive_tree(rpc_client: RPCClient):
@@ -82,7 +84,7 @@ def test_load_interactive_tree(rpc_client: RPCClient):
     resp0 = rpc_client.get_heartbeat()
     assert resp0.behavior_tree_update[0].tick_status == TickStatus.INVALID
     wait_until(partial(assert_test_status,
-                       rpc_client, "Eternal Guard", TreeStatus.WAITING_ACK))
+                       rpc_client, "my_tree", TreeStatus.WAITING_ACK))
 
     # tick tree
     rpc_client.tick_tree("my_tree")
@@ -90,10 +92,27 @@ def test_load_interactive_tree(rpc_client: RPCClient):
 
     # back to waiting for tick
     wait_until(partial(assert_test_status,
-                       rpc_client, "Eternal Guard", TreeStatus.WAITING_ACK))
+                       rpc_client, "my_tree", TreeStatus.WAITING_ACK))
 
 
 def test_pause_tree(rpc_client: RPCClient):
+    tree_path = Path(__file__).parent / "artifacts" / "eternal_guard.json"
+    rpc_client.load_new_tree(
+        new_tree_filepath=str(tree_path),
+        tick_config="CONTINUOUS",
+        tick_delay_ms=10,
+        tree_name="my_tree"
+    )
+
+    wait_until(partial(assert_test_status, rpc_client, "my_tree", TreeStatus.IDLE))
+    rpc_client.start_tree("my_tree")
+    wait_until(partial(assert_test_status, rpc_client,
+                       "my_tree", TreeStatus.TICKING))
+    rpc_client.pause_tree("my_tree")
+    wait_until(partial(assert_test_status, rpc_client, "my_tree", TreeStatus.IDLE))
+
+
+def test_tree_details(rpc_client: RPCClient):
     tree_path = Path(__file__).parent / "artifacts" / "eternal_guard.json"
     rpc_client.load_new_tree(
         new_tree_filepath=str(tree_path),
@@ -102,7 +121,47 @@ def test_pause_tree(rpc_client: RPCClient):
         tree_name="my_tree"
     )
 
-    wait_until(partial(assert_test_status, rpc_client, "Eternal Guard", TreeStatus.IDLE))
-
+    wait_until(partial(assert_test_status, rpc_client, "my_tree", TreeStatus.IDLE))
     rpc_client.start_tree("my_tree")
-    wait_until(partial(assert_test_status, rpc_client, "Eternal Guard", TreeStatus.TICKING))
+    # tick the tree to get some real statuses
+    rpc_client.tick_tree("my_tree")
+    wait_until(partial(assert_test_status, rpc_client,
+                       "my_tree", TreeStatus.WAITING_ACK))
+
+    details = rpc_client.get_detailed_update(tree_name="my_tree")
+    assert details.tree_id.name == "my_tree"
+    assert details.tree_status == TreeStatus.WAITING_ACK
+    assert details.node_info.id.name == "Eternal Guard"
+    assert len(details.node_info.children) == 3
+    assert details.node_info.children[0].id.name == "Condition 1"
+
+
+def test_uuid_matching(rpc_client: RPCClient):
+    tree_path = Path(__file__).parent / "artifacts" / "eternal_guard.json"
+    rpc_client.load_new_tree(
+        new_tree_filepath=str(tree_path),
+        tick_config="INTERACTIVE",
+        tick_delay_ms=10,
+        tree_name="eg"
+    )
+    rpc_client.tick_tree(tree_name="eg")
+
+    tree_path_2 = Path(__file__).parent / "artifacts" / "eggs.json"
+    rpc_client.load_new_tree(
+        new_tree_filepath=str(tree_path_2),
+        tick_config="INTERACTIVE",
+        tick_delay_ms=10,
+        tree_name="egg"
+    )
+    rpc_client.tick_tree(tree_name="egg")
+
+    wait_until(lambda: len(rpc_client.get_heartbeat().behavior_tree_update) == 2)
+    heartbeat = rpc_client.get_heartbeat()
+
+    for msg in heartbeat.behavior_tree_update:
+        print(msg.tree_id)
+        name_details = rpc_client.get_detailed_update(tree_name=msg.tree_id.name)
+        uuid_details = rpc_client.get_detailed_update(tree_uuid=msg.tree_id.uuid)
+        assert isinstance(name_details, TreeDetails)
+        assert isinstance(uuid_details, TreeDetails)
+        assert name_details == uuid_details

--- a/beams/tests/test_service_proto_messages.py
+++ b/beams/tests/test_service_proto_messages.py
@@ -1,7 +1,9 @@
+from uuid import uuid4
+
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from beams.service.remote_calls.behavior_tree_pb2 import (
-    BehaviorTreeUpdateMessage, TickConfiguration, TickStatus)
+    BehaviorTreeUpdateMessage, NodeId, TickConfiguration, TickStatus)
 from beams.service.remote_calls.command_pb2 import (AckNodeMessage,
                                                     CommandMessage,
                                                     CommandType,
@@ -20,27 +22,27 @@ class TestProtos:
     def test_behavior_tree_messages(self):
         y = BehaviorTreeUpdateMessage(
                 mess_t=MessageType.MESSAGE_TYPE_BEHAVIOR_TREE_MESSAGE,
-                tree_name="CoolTree",
-                node_name="current_node",
+                tree_id=NodeId(name="CoolTree", uuid=str(uuid4())),
+                node_id=NodeId(name="current_node", uuid=str(uuid4())),
                 tick_status=TickStatus.RUNNING,
                 tick_config=TickConfiguration.INTERACTIVE,
                 tick_delay_ms=200
             )
-        assert y.tree_name == "CoolTree"
+        assert y.tree_id.name == "CoolTree"
 
     def test_heartbeat(self):
         tree1 = BehaviorTreeUpdateMessage(
             mess_t=MessageType.MESSAGE_TYPE_BEHAVIOR_TREE_MESSAGE,
-            tree_name="Tree1",
-            node_name="current_node",
+            tree_id=NodeId(name="Tree1", uuid=str(uuid4())),
+            node_id=NodeId(name="current_node", uuid=str(uuid4())),
             tick_status=TickStatus.RUNNING,
             tick_config=TickConfiguration.INTERACTIVE,
             tick_delay_ms=200
         )
         tree2 = BehaviorTreeUpdateMessage(
             mess_t=MessageType.MESSAGE_TYPE_BEHAVIOR_TREE_MESSAGE,
-            tree_name="Tree2",
-            node_name="current_node",
+            tree_id=NodeId(name="Tree2", uuid=str(uuid4())),
+            node_id=NodeId(name="current_node", uuid=str(uuid4())),
             tick_status=TickStatus.RUNNING,
             tick_config=TickConfiguration.INTERACTIVE,
             tick_delay_ms=200
@@ -53,8 +55,8 @@ class TestProtos:
         )
 
         # protobuf asserts order is maintained
-        assert z.behavior_tree_update[0].tree_name == "Tree1"
-        assert z.behavior_tree_update[1].tree_name == "Tree2"
+        assert z.behavior_tree_update[0].tree_id.name == "Tree1"
+        assert z.behavior_tree_update[1].tree_id.name == "Tree2"
 
     # can better test to show how optionals can be desrialized
     def test_command_message(self):

--- a/beams/tests/test_treeidkey.py
+++ b/beams/tests/test_treeidkey.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict
+from uuid import UUID
+
+import pytest
+
+from beams.service.rpc_handler import TreeIdKey
+
+
+@pytest.mark.parametrize("comparison, is_match,", [
+    ("my rather long name", True),
+    ("my rather ", False),
+    (UUID("435f6dd5-0b2e-41c4-b07e-479a83271680"), True),
+    (UUID("435f6dd5-0b2e-41c4-b07e-aaaaaaaaaaaa"), False),
+    ("435f6dd", True),
+])
+def test_treeidkey_equality(comparison: Any, is_match: bool):
+    tree_key = TreeIdKey(name="my rather long name",
+                         uuid=UUID("435f6dd5-0b2e-41c4-b07e-479a83271680"))
+    assert (tree_key == comparison) is is_match
+
+
+@pytest.fixture
+def tree_dict() -> Dict[TreeIdKey, int]:
+    return {
+        TreeIdKey(name="tree1",
+                  uuid=UUID("9218d74e-b6c5-4fa3-8249-4ac45abc09fb")): 1,
+        TreeIdKey(name="tree1",
+                  uuid=UUID("50c82a04-7ce6-4656-bf2d-e26b08d8addf")): 2,
+        TreeIdKey(name="tree3",
+                  uuid=UUID("94b74b64-ad96-41dd-8489-1162032804a8")): 3,
+    }
+
+
+@pytest.mark.parametrize("key, expected_value", [
+    (TreeIdKey(name="tree1", uuid=UUID("9218d74e-b6c5-4fa3-8249-4ac45abc09fb")), 1),
+    (TreeIdKey(name="tree1", uuid=UUID("50c82a04-7ce6-4656-bf2d-e26b08d8addf")), 2),
+    (TreeIdKey(name="tree3", uuid=UUID("94b74b64-ad96-41dd-8489-1162032804a8")), 3),
+    (UUID("9218d74e-b6c5-4fa3-8249-4ac45abc09fb"), 1),
+    # dict checks hash of object before equality, and don't consider name
+    (UUID("50c82a04-7ce6-4656-bf2d-e26b08d8addf"), 2),
+    (TreeIdKey(name="notmynname", uuid=UUID("9218d74e-b6c5-4fa3-8249-4ac45abc09fb")), 1),
+    (UUID("94b74b64-ad96-41dd-8489-1162032804a8"), 3),
+    ("tree1", None),  # hashes in dict are with uuid
+    ("9218d74", None),
+])
+def test_treeidkey_getitem(
+    tree_dict: Dict[TreeIdKey, int],
+    key: TreeIdKey,
+    expected_value: int
+):
+    if expected_value is None:
+        with pytest.raises(KeyError):
+            tree_dict[key]
+
+        assert tree_dict.get(key) is None
+    else:
+        assert tree_dict[key] == expected_value
+        assert tree_dict.get(key) == expected_value

--- a/docs/source/upcoming_release_notes/109-enh_detailed_proto.rst
+++ b/docs/source/upcoming_release_notes/109-enh_detailed_proto.rst
@@ -1,0 +1,31 @@
+109 enh_detailed_proto
+######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds the ability for the BEAMS service to provide detailed messages to a client, including the name, uuid, and status of every node in a tree
+  - Adds `TreeDetails` proto message, which holds `NodeInfo`
+  - Adds `NodeInfo`, a recursive message that details the node id, its status, and its childrens' `NodeInfo`
+  - Adds code paths for the service to create and return these `TreeDetails` objects
+
+- Adjusts the `RPCHandler` and `TreeTicker` to use UUIDs as the primary method of identifying trees
+  - the "tree_dict" passed around is now keyed by a `TreeIdKey` object, which handles equality checks between both strings and uuids (in addition to its own type)
+  - Ensures that the "name" used to identify the tree is the one the client provides, not the name specified in a tree config file
+  - multiple trees that use the same config file can be loaded.  This will result in identical trees, each with a different UUID used to track it.
+
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
 ## Description
- Adds the ability for the BEAMS service to provide detailed messages to a client, including the name, uuid, and status of every node in a tree
  - Adds `TreeDetails` proto message, which holds `NodeInfo`
  - Adds `NodeInfo`, a recursive message that details the node id, its status, and its childrens' `NodeInfo`
  - Adds code paths for the service to create and return these `TreeDetails` objects

- Adjusts the `RPCHandler` and `TreeTicker` to use UUIDs as the primary method of identifying trees
  - the "tree_dict" passed around is now keyed by a `TreeIdKey` object, which handles equality checks between both strings and uuids (in addition to its own type) 
  - Ensures that the "name" used to identify the tree is the one the client provides, not the name specified in a tree config file
  - multiple trees that use the same config file can be loaded.  This will result in identical trees, each with a different UUID used to track it.  

I was tempted every day to move `beams.bin.service_main.BeamsService` into the same submodule as `RPCHandler`, but for the sake of the diff readability I'm punting that

To do in a followup: have the cli know about detailed messages
 
## Motivation and Context
Wow how did I end up down this rabbit hole?

I wanted detailed tree messages so that I could represent a ticking tree in a GUI application.   To do this, we'd need to uniquely identify every node and know its status.  The names given to nodes are almost certainly not unique, so we needed another way to identify them.  Luckily pytrees already attaches a uuid to them, so all we needed to do is pull that out.

While we're here, we should also make sure that trees are identified meaningfully.  We can't expect every user to come up with a unique name for their tree when loading it into the service.  How we deal with collisions here is an open question, but if we ever do want to allow identical names, we'll need some way to differentiate them.  Hence uuids to id trees as well.

### Some other notes:
* Proto messages only allow you to modify non-message members on existing messages.  This means that if we want to update a message before returning it, sometimes we need to recreate the entire message with information from the old one.
* `SyncManager`'s return an `AutoProxy` for the objects they hold onto and synchronize.  These special objects take care of updating the manager when a value has changed, but also aren't exactly the same as the previous objects
  * `AutoProxy`s expose methods, but not attributes or subscripting (`object[]` type access)
  * `AutoProxy` objects are not guaranteed to have a stable address / id, meaning you can't check against identity
    * note how the following produces different addresses for the `TreeTicker` objects in the dictionary
    *  ```python
        > tree_dict.items()
        [(TreeIdKey(name='eg', uuid=UUID('d0089968-b4a4-4189-ac61-893f30e871c0')), <AutoProxy[TreeTicker] object, typeid 'TreeTicker' at 0x7fa4f5fcd1f0>)]
        > tree_dict.items()
        [(TreeIdKey(name='eg', uuid=UUID('d0089968-b4a4-4189-ac61-893f30e871c0')), <AutoProxy[TreeTicker] object, typeid 'TreeTicker' at 0x7fa4f5fccda0>)]
        > tree_dict.items()
        [(TreeIdKey(name='eg', uuid=UUID('d0089968-b4a4-4189-ac61-893f30e871c0')), <AutoProxy[TreeTicker] object, typeid 'TreeTicker' at 0x7fa4f5fcc1d0>)]
       ```
    * I still hinted them as their non `AutoProxy` object types, for the sake of type checkers doing reasonable things

## How Has This Been Tested?
Interactively, and tests have been added

<img width="1188" height="697" alt="image" src="https://github.com/user-attachments/assets/3e1ab6fb-bb7f-4a42-85be-0b8f5b34ab74" />

New heartbeat with uuid info
<img width="825" height="389" alt="image" src="https://github.com/user-attachments/assets/5256d7ad-6f91-476d-97da-ce446efa8765" />


## Where Has This Been Documented?
This PR, lots of comments.  I need to make another pass though.

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
