### PR TITLE
ENH: Augment detailed tree proto to include node type

### DIFF
--- a/beams/service/remote_calls/behavior_tree.proto
+++ b/beams/service/remote_calls/behavior_tree.proto
@@ -44,7 +44,8 @@ message BehaviorTreeUpdateMessage {
 message NodeInfo {
   NodeId id = 1;
   TickStatus status = 2;
-  repeated NodeInfo children = 3;
+  string type = 3;
+  repeated NodeInfo children = 4;
 }
 
 message TreeDetails {

--- a/beams/service/rpc_client.py
+++ b/beams/service/rpc_client.py
@@ -174,7 +174,7 @@ class RPCClient:
         if command.upper() == "GET_TREE_DETAILS":
             return self.get_detailed_update(tree_name=tree_name, tree_uuid=tree_uuid)
 
-        command = getattr(CommandType, command.upper())
+        command: CommandType = getattr(CommandType, command.upper())
         if command not in CommandType.values():
             raise ValueError(f"Unsupported command provided: {command}")
 

--- a/beams/service/tree_ticker.py
+++ b/beams/service/tree_ticker.py
@@ -268,6 +268,7 @@ class TreeTicker(Worker):
             return NodeInfo(
                 id=NodeId(name=node.name, uuid=str(node.id)),
                 status=getattr(TickStatus, node.status.name),
+                type=type(node).__name__,
                 children=child_info,
             )
 

--- a/beams/tests/test_qt_models.py
+++ b/beams/tests/test_qt_models.py
@@ -83,18 +83,21 @@ def eternal_guard_details() -> TreeDetails:
 
 def assert_base_qtbtreeitem_info(tree_item: QtBTreeItem):
     # walks DFS
+    tree_items = tree_item.walk_tree()
+    next(tree_items)  # skip root, can differ depending on source
+
     for item, name, node_type in zip(
-        tree_item.walk_tree(),
-        ["<root>", "Eternal Guard", "Condition 1", "Condition 2", "Task Sequence",
+        tree_items,
+        ["Eternal Guard", "Condition 1", "Condition 2", "Task Sequence",
          "Worker 1", "Worker 2"],
-        ["", "Sequence", "StatusQueue", "StatusQueue", "Sequence", "Success",
+        ["Sequence", "StatusQueue", "StatusQueue", "Sequence", "Success",
          "Running"],
     ):
         assert item.name == name
         assert item.node_type == node_type
 
 
-def test_create_qttreeitem(eternal_guard_item):
+def test_create_qttreeitem_from_tree(eternal_guard_item):
     tree_item = QtBTreeItem.from_behavior_tree_item(eternal_guard_item)
     assert tree_item.children[0].name == "Eternal Guard"
 
@@ -115,5 +118,15 @@ def test_update_qtitem_with_details(eternal_guard_item, eternal_guard_details):
     for item in tree_item.walk_tree():
         assert item.status is not TickStatus.INVALID
         assert item.node_id is not None
+
+    assert_base_qtbtreeitem_info(tree_item)
+
+
+def test_create_qtbtreeitem_from_treedetails(eternal_guard_details):
+    tree_item = QtBTreeItem.from_tree_details(eternal_guard_details)
+    assert tree_item.children[0].name == "Eternal Guard"
+
+    for child, child_ct in zip(tree_item.children[0].children, [0, 0, 2]):
+        assert len(child.children) == child_ct
 
     assert_base_qtbtreeitem_info(tree_item)

--- a/beams/tests/test_qt_models.py
+++ b/beams/tests/test_qt_models.py
@@ -28,6 +28,7 @@ def eternal_guard_details() -> TreeDetails:
                 uuid="56e4da1e-b3a9-4dc8-b27a-1c82cd0ba68d",
             ),
             status=TickStatus.RUNNING,
+            type="Sequence",
             children=[
                 NodeInfo(
                     id=NodeId(
@@ -35,6 +36,7 @@ def eternal_guard_details() -> TreeDetails:
                         uuid="05a83efd-6318-408f-9737-25f01d2d3090",
                     ),
                     status=TickStatus.SUCCESS,
+                    type="StatusQueue",
                     children=[],
                 ),
                 NodeInfo(
@@ -43,6 +45,7 @@ def eternal_guard_details() -> TreeDetails:
                         uuid="a33b309c-08cc-4922-a61d-bb3a4c799165",
                     ),
                     status=TickStatus.SUCCESS,
+                    type="StatusQueue",
                     children=[],
                 ),
                 NodeInfo(
@@ -51,6 +54,7 @@ def eternal_guard_details() -> TreeDetails:
                         uuid="c201a150-b6f2-4afe-aa0a-4c52aa4a8a87",
                     ),
                     status=TickStatus.RUNNING,
+                    type="Sequence",
                     children=[
                         NodeInfo(
                             id=NodeId(
@@ -58,6 +62,7 @@ def eternal_guard_details() -> TreeDetails:
                                 uuid="e8f2c943-fc22-4a3a-993a-c2f4c44f8651",
                             ),
                             status=TickStatus.SUCCESS,
+                            type="Success",
                         ),
                         NodeInfo(
                             id=NodeId(
@@ -65,6 +70,7 @@ def eternal_guard_details() -> TreeDetails:
                                 uuid="2c654b9e-8659-444f-96ef-d9b20fec9c5f",
                             ),
                             status=TickStatus.RUNNING,
+                            type="Running",
                         ),
                     ],
                 ),

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -108,17 +108,18 @@ class QtBTreeItem:
         ValueError
             If the provided NodeInfo does not match the tree item being updated.
         """
-        # TODO figure out a better way to check the tree matches the node_info
-        # perhaps checking all tree-structure with encoded tree?
-        # perhaps adjust tree details proto to also encode node types
         self.node_id = UUID(node_info.id.uuid)
         self.status = getattr(Status, TickStatus.Name(node_info.status))
 
         # This is the simplest check I could think of to verify the two tree
         # structures matched
         if len(self.children) != len(node_info.children):
-            raise ValueError("Provided details do not match the tree being"
+            raise ValueError("Provided details do not match the tree being "
                              "updated.  (number of children mismatched)")
+        if self.node_type != node_info.type:
+            raise ValueError("Provided details do not match the tree being "
+                             "updated.  Node types mismatch: "
+                             f"{self.node_type} vs {node_info.type}")
         for item_c, node_c in zip(self.children, node_info.children):
             item_c.update_from_node_info(node_c)
 

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -65,8 +65,6 @@ class QtBTreeItem:
         This assumes that self is the top-level root node, with only one child.
         This method handles the root node and calls :py:meth:`~.update_from_node_info`.
 
-        see:
-
         Parameters
         ----------
         details : TreeDetails
@@ -95,7 +93,7 @@ class QtBTreeItem:
         Update this tree item from a node_info object.
 
         In contrast to :py:meth:`~.update_from_tree_details`, this must be
-        called from a node that is not the root
+        called from a node that is not the root.
 
         Parameters
         ----------

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -126,7 +126,7 @@ class QtBTreeItem:
     @classmethod
     def from_behavior_tree_item(cls, tree: BehaviorTreeItem) -> QtBTreeItem:
         """
-        Convert from BehaviorTreeItem to QT-BehaviorTreeItem from.
+        Convert from `BehaviorTreeItem` to QT-BehaviorTreeItem.
         A `BehaviorTreeItem` is the deserialized BEAMS tree object.
 
         Parameters
@@ -137,7 +137,6 @@ class QtBTreeItem:
         Returns
         -------
         QtBTreeItem
-            _description_
         """
         def _inner_get_tree_item(tree: BaseItem) -> QtBTreeItem:
             item = QtBTreeItem(
@@ -152,6 +151,47 @@ class QtBTreeItem:
 
         tree_root_item = _inner_get_tree_item(tree.root)
         root_item = QtBTreeItem(name="<root>")
+        root_item.addChild(tree_root_item)
+        return root_item
+
+    @classmethod
+    def from_tree_details(cls, tree: TreeDetails) -> QtBTreeItem:
+        """
+        Convert from `TreeDetails` to QT-BehaviorTreeItem.
+        `TreeDetails` is the proto message from the BEAMS service.
+        Use this if you want to represent a tree entirely with information
+        from the service.
+
+        Parameters
+        ----------
+        tree : TreeDetails
+            TreeDetails message to create a QtBTreeItem from
+
+        Returns
+        -------
+        QtBTreeItem
+        """
+        def _inner_get_tree_item(info: NodeInfo) -> QtBTreeItem:
+            item = QtBTreeItem(
+                name=info.id.name,
+                node_type=info.type,
+                node_id=UUID(info.id.uuid),
+                status=info.status
+            )
+            if hasattr(info, "children"):
+                children = [_inner_get_tree_item(child) for child in info.children]
+                for child in children:
+                    item.addChild(child)
+
+            return item
+
+        tree_root_item = _inner_get_tree_item(tree.node_info)
+        root_item = QtBTreeItem(
+            name=tree.tree_id.name,
+            node_id=UUID(tree.tree_id.uuid),
+            node_type="<root>",
+            status=tree.tree_status,
+        )
         root_item.addChild(tree_root_item)
         return root_item
 

--- a/docs/source/upcoming_release_notes/114-enh_type_detailed_proto.rst
+++ b/docs/source/upcoming_release_notes/114-enh_type_detailed_proto.rst
@@ -1,0 +1,24 @@
+114 enh_type_detailed_proto
+###########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds `type` to the `TreeDetails` proto
+- Adds checks in the `QtBTreeItem` update methods that reference this information
+- Adds constructor methods to create a `QtBTreeItem` entirely from a `TreeDetails` message
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Adds `type` to the `TreeDetails` proto
- Adds checks in the `QtBTreeItem` update methods that reference this information
- Adds constructor methods to create a `QtBTreeItem` entirely from a `TreeDetails` message
  - for use in displaying tree information from the service

## Motivation and Context
Ew it's all string comparison.  Surely this doesn't bite us later.

## How Has This Been Tested?
Some tests have been added and modified

## Where Has This Been Documented?
This PR, and some docstrings

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
