### PR TITLE
WIP/ENH: add Monitor page

### DIFF
--- a/beams/tests/conftest.py
+++ b/beams/tests/conftest.py
@@ -211,3 +211,8 @@ TEST_CONFIG_PATHS = test_configs()
 @pytest.fixture(params=TEST_CONFIG_PATHS)
 def configs(request):
     return request.param
+
+
+@pytest.fixture
+def dummy_beams_config():
+    os.environ["BEAMS_CFG"] = str(Path(__file__).parent / "config.cfg")

--- a/beams/tests/test_monitor_page.py
+++ b/beams/tests/test_monitor_page.py
@@ -1,0 +1,193 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import Qt
+
+from beams.service.remote_calls.behavior_tree_pb2 import (NodeId, TickStatus,
+                                                          TreeDetails,
+                                                          TreeStatus)
+from beams.service.remote_calls.heartbeat_pb2 import HeartBeatReply
+from beams.service.rpc_client import RPCClient
+from beams.widgets.monitor import MonitorPage
+
+# Some constants for our tests
+TREE_ID_UUID = str(uuid.uuid4())
+TREE_ID_NAME = "test_tree"
+ROOT_NODE_UUID = str(uuid.uuid4())
+ROOT_NODE_NAME = "root_node"
+CHILD_NODE_UUID = str(uuid.uuid4())
+CHILD_NODE_NAME = "child_node"
+
+
+@pytest.fixture
+def tree_id() -> NodeId:
+    """Fixture for a sample NodeId."""
+    return NodeId(uuid=TREE_ID_UUID, name=TREE_ID_NAME)
+
+
+@pytest.fixture
+def mock_rpc_client(tree_id: NodeId) -> RPCClient:
+    """
+    Fixture to create a mock RPCClient.
+
+    This mock client generates an identical detailed update whenever requested
+    The generated heartbeat is generated once and does not update
+    """
+    client = MagicMock(spec=RPCClient)
+
+    # Mock get_heartbeat response
+    heartbeat = HeartBeatReply()
+    timestamp = Timestamp()
+    timestamp.GetCurrentTime()
+    heartbeat.reply_timestamp.CopyFrom(timestamp)
+    tree_update = heartbeat.behavior_tree_update.add()
+    tree_update.tree_id.CopyFrom(tree_id)
+    tree_update.tree_status = TreeStatus.IDLE
+    tree_update.tick_status = TickStatus.SUCCESS
+    tree_update.node_id.name = ROOT_NODE_NAME
+    tree_update.node_id.uuid = ROOT_NODE_UUID
+    client.get_heartbeat.return_value = heartbeat
+
+    # Mock get_detailed_update response
+    def get_new_details(*args, **kwargs):
+        tree_details = TreeDetails()
+        tree_details.tree_id.CopyFrom(tree_id)
+        tree_details.tree_status = TreeStatus.IDLE
+        root_node = tree_details.node_info
+        root_node.id.uuid = ROOT_NODE_UUID
+        root_node.id.name = ROOT_NODE_NAME
+        root_node.status = TickStatus.SUCCESS
+        root_node.type = "Sequence"
+        child_node = root_node.children.add()
+        child_node.id.uuid = CHILD_NODE_UUID
+        child_node.id.name = CHILD_NODE_NAME
+        child_node.status = TickStatus.SUCCESS
+        child_node.type = "SetPVAction"
+        return tree_details
+
+    client.get_detailed_update.side_effect = get_new_details
+
+    return client
+
+
+@pytest.fixture
+def monitor_page(qtbot: QtBot, tree_id: NodeId, mock_rpc_client: RPCClient):
+    """Fixture to create a MonitorPage widget."""
+    widget = MonitorPage(tree_id=tree_id, client=mock_rpc_client)
+    qtbot.add_widget(widget)
+    return widget
+
+
+def test_monitor_page_creation(monitor_page: MonitorPage):
+    """Test that the MonitorPage widget can be created."""
+    assert monitor_page is not None
+    assert monitor_page.tree_id.uuid == TREE_ID_UUID
+    assert monitor_page.tick_history == []
+
+
+# @patch('beams.widgets.monitor.MonitorPage.update_node_status')
+def test_grab_tick(monitor_page: MonitorPage, mock_rpc_client: MagicMock, qtbot: QtBot):
+    """Test that grab_tick fetches data and updates the history."""
+    assert len(monitor_page.tick_history) == 0
+
+    monitor_page.grab_tick()
+
+    assert len(monitor_page.tick_history) == 1
+    mock_rpc_client.get_heartbeat.assert_called_once()
+    mock_rpc_client.get_detailed_update.assert_called_once()
+
+    # Check that the snapshot was created correctly
+    snapshot = monitor_page.tick_history[0]
+    assert snapshot.tree_update.tree_id.uuid == TREE_ID_UUID
+    assert snapshot.tree_item.name == TREE_ID_NAME
+
+    # Check that the UI is updated
+    assert monitor_page.num_counts_label.text() == "/ 1"
+    assert monitor_page.tick_slider.minimum() == 0
+    assert monitor_page.tick_slider.maximum() == 0
+    assert monitor_page.tick_spin_box.minimum() == 1
+    assert monitor_page.tick_spin_box.maximum() == 1
+
+    # Test the next and previous tick buttons
+    # Add two ticks to the history
+    monitor_page.grab_tick()
+    monitor_page.grab_tick()
+
+    # Should start at the first tick (index 0)
+    monitor_page.update_display_for_tick(0)
+    assert monitor_page.tick_slider.value() == 0
+
+    # Click next (tick 2)
+    qtbot.mouseClick(monitor_page.next_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 1
+
+    # Click next (tick 3)
+    qtbot.mouseClick(monitor_page.next_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 2
+
+    # Click next again (should do nothing)
+    qtbot.mouseClick(monitor_page.next_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 2
+
+    # Click previous
+    qtbot.mouseClick(monitor_page.prev_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 1
+
+    # Click previous again
+    qtbot.mouseClick(monitor_page.prev_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 0
+
+    # Click previous again (should do nothing)
+    qtbot.mouseClick(monitor_page.prev_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 0
+
+
+@patch('beams.widgets.monitor.MonitorPage.update_node_status')
+def test_slider_interaction(mock_update, monitor_page: MonitorPage, qtbot: QtBot):
+    """Test that moving the slider updates the display."""
+    # Add three ticks to the history
+    monitor_page.grab_tick()
+    monitor_page.grab_tick()
+    monitor_page.grab_tick()
+
+    # Move slider to the middle position
+    monitor_page.tick_slider.setValue(1)
+    # The spin box is 1-indexed
+    assert monitor_page.tick_spin_box.value() == 2
+
+
+@patch('beams.widgets.monitor.MonitorPage.update_node_status')
+def test_spin_box_interaction(mock_update, monitor_page: MonitorPage, qtbot: QtBot):
+    """Test that changing the spin box updates the display."""
+    # Add three ticks to the history
+    monitor_page.grab_tick()
+    monitor_page.grab_tick()
+    monitor_page.grab_tick()
+
+    # Set spin box to the second tick
+    monitor_page.tick_spin_box.setValue(2)
+    # The slider is 0-indexed
+    assert monitor_page.tick_slider.value() == 1
+
+
+def test_auto_arrange_button(monitor_page: MonitorPage, qtbot: QtBot):
+    """Test that the auto-arrange button calls the scene's auto-arrange."""
+    with patch.object(monitor_page.node_editor.scene, 'auto_arrange') as mock_auto_arrange:
+        qtbot.mouseClick(monitor_page.auto_arrange_button, Qt.LeftButton)
+        mock_auto_arrange.assert_called_once()
+
+
+def test_buttons_with_no_history(monitor_page: MonitorPage, qtbot: QtBot):
+    """Test that the next/prev buttons do nothing with no history."""
+    assert monitor_page.tick_history == []
+    # Slider is at 0, let's confirm it doesn't move
+    assert monitor_page.tick_slider.value() == 0
+
+    qtbot.mouseClick(monitor_page.next_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 0
+
+    qtbot.mouseClick(monitor_page.prev_step_button, Qt.LeftButton)
+    assert monitor_page.tick_slider.value() == 0

--- a/beams/tests/test_window.py
+++ b/beams/tests/test_window.py
@@ -3,7 +3,7 @@ from pytestqt.qtbot import QtBot
 from beams.widgets.window import MainWindow
 
 
-def test_main_window(qtbot: QtBot):
+def test_main_window(qtbot: QtBot, dummy_beams_config):
     window = MainWindow()
     qtbot.add_widget(window)
 

--- a/beams/ui/heartbeat_info.ui
+++ b/beams/ui/heartbeat_info.ui
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>461</width>
+    <height>231</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="tree_info_header_label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Tree Info</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDateTimeEdit" name="datetime_edit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="frame">
+        <bool>true</bool>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="delay_spin_box">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>1000000000</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="uuid_label">
+       <property name="text">
+        <string>UUID</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="mode_combo_box">
+       <property name="editable">
+        <bool>false</bool>
+       </property>
+       <item>
+        <property name="text">
+         <string>UNKNOWN</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>INTERACTIVE</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>CONTINUOUS</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="name_label">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="uuid_disp_label">
+       <property name="text">
+        <string>[uuid]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="name_disp_label">
+       <property name="text">
+        <string>[name]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="tick_mode_label">
+       <property name="text">
+        <string>Tick Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="tick_delay_label">
+       <property name="text">
+        <string>Tick delay (ms)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="tree_status_label">
+       <property name="text">
+        <string>Status</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="tree_status_disp_label">
+       <property name="text">
+        <string>[status]</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="tip_info_header_label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Tip Node Info</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="tip_name_label">
+       <property name="text">
+        <string>Node Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="tip_name_disp_label">
+       <property name="text">
+        <string>[node name]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="tip_status_label">
+       <property name="text">
+        <string>Node Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="tip_status_disp_label">
+       <property name="text">
+        <string>[node status]</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/beams/ui/monitor_page.ui
+++ b/beams/ui/monitor_page.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>monitor_page</class>
+ <widget class="QWidget" name="monitor_page">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>773</width>
+    <height>612</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QVBoxLayout" name="tree_view_info_vlayout">
+       <item>
+        <widget class="QTreeView" name="tree_view">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="hb_info_placeholder" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="monitor_widgets" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>3</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QWidget" name="node_widget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="button_layout">
+         <item>
+          <widget class="QPushButton" name="update_button">
+           <property name="text">
+            <string>Get Update</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="auto_arrange_button">
+           <property name="text">
+            <string>Auto-arrange</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="history_hlayout">
+     <item>
+      <widget class="QToolButton" name="prev_step_button">
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="next_step_button">
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="tick_slider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="tick_count_label">
+       <property name="text">
+        <string>Tick:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="tick_spin_box"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="num_counts_label">
+       <property name="text">
+        <string>/ ??</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/beams/ui/tree_selector.ui
+++ b/beams/ui/tree_selector.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tab_widget">
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Tab 1</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/beams/widgets/edit.py
+++ b/beams/widgets/edit.py
@@ -6,12 +6,13 @@ from pathlib import Path
 from typing import Optional, Union
 
 from qtpy import QtWidgets
-from qtpynodeeditor import FlowView, PortType
+from qtpynodeeditor import FlowView
 
 from beams.tree_config.base import BehaviorTreeItem
 from beams.widgets.core import DesignerDisplay, insert_widget
 from beams.widgets.node_models import create_editor_view, tree_from_graph
-from beams.widgets.qt_models import BehaviorTreeModel, QtBTreeItem
+from beams.widgets.qt_models import (BehaviorTreeModel, QtBTreeItem,
+                                     create_scene_nodes)
 
 logger = logging.getLogger(__name__)
 
@@ -103,23 +104,7 @@ class EditPage(DesignerDisplay, QtWidgets.QWidget):
         tree_item = QtBTreeItem.from_behavior_tree_item(tree)
         scene = self.node_editor.scene
 
-        def _inner_create_node(tree_item: QtBTreeItem):
-            if tree_item.node_type == "":
-                model_name = " Root "  # TODO: deal with this spacing issue upstream
-            else:
-                model_name = tree_item.node_type
-            model_cls = scene.registry.get_model_by_name(model_name)[0]
-            node = scene.create_node(model_cls)
-
-            for i, child in enumerate(tree_item.children):
-                child_node = _inner_create_node(child)
-                scene.create_connection(
-                    node[PortType.output][i], child_node[PortType.input][0]
-                )
-
-            return node
-
-        _ = _inner_create_node(tree_item)
+        create_scene_nodes(scene, tree_item)
 
         self.auto_arrange_nodes()
 

--- a/beams/widgets/heartbeat_info.py
+++ b/beams/widgets/heartbeat_info.py
@@ -1,0 +1,57 @@
+import datetime
+
+from qtpy.QtWidgets import QComboBox, QDateTimeEdit, QLabel, QSpinBox, QWidget
+
+from beams.service.remote_calls.behavior_tree_pb2 import (
+    BehaviorTreeUpdateMessage, TickStatus, TreeStatus)
+from beams.widgets.core import DesignerDisplay
+
+
+class HeartbeatInfo(DesignerDisplay, QWidget):
+    filename = "heartbeat_info.ui"
+
+    datetime_edit: QDateTimeEdit
+
+    name_disp_label: QLabel
+    uuid_disp_label: QLabel
+    tree_status_disp_label: QLabel
+    mode_combo_box: QComboBox
+    delay_spin_box: QSpinBox
+
+    tip_name_disp_label: QLabel
+    tip_status_disp_label: QLabel
+
+    def __init__(
+        self,
+        *args,
+        tree_update: BehaviorTreeUpdateMessage,
+        timestamp: datetime.datetime,
+        read_only: bool = True,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        self.timestamp = timestamp
+        self.update_msg = tree_update
+        self.read_only = read_only
+        self.update_from_msg(timestamp, self.update_msg)
+
+    def update_from_msg(
+        self,
+        timestamp: datetime.datetime,
+        msg: BehaviorTreeUpdateMessage
+    ):
+        self.mode_combo_box.setEnabled(not self.read_only)
+        self.delay_spin_box.setEnabled(not self.read_only)
+
+        self.datetime_edit.setDateTime(timestamp)
+
+        self.name_disp_label.setText(msg.tree_id.name)
+        self.uuid_disp_label.setText(msg.tree_id.uuid)
+        self.tree_status_disp_label.setText(TreeStatus.Name(msg.tree_status))
+
+        self.mode_combo_box.setCurrentIndex(msg.tick_config)
+        self.delay_spin_box.setValue(msg.tick_delay_ms)
+
+        self.tip_name_disp_label.setText(msg.node_id.name)
+        self.tip_status_disp_label.setText(TickStatus.Name(msg.tick_status))

--- a/beams/widgets/monitor.py
+++ b/beams/widgets/monitor.py
@@ -10,7 +10,8 @@ from functools import partial
 from typing import List, Optional
 
 from qtpy import QtWidgets
-from qtpynodeeditor import FlowView
+from qtpy.QtGui import QColor
+from qtpynodeeditor import FlowView, Node
 
 from beams.service.remote_calls.behavior_tree_pb2 import (
     BehaviorTreeUpdateMessage, NodeId)
@@ -18,7 +19,9 @@ from beams.service.rpc_client import RPCClient
 from beams.widgets.core import DesignerDisplay, insert_widget
 from beams.widgets.heartbeat_info import HeartbeatInfo
 from beams.widgets.node_models import create_editor_view
-from beams.widgets.qt_models import BehaviorTreeModel, QtBTreeItem
+from beams.widgets.qt_models import (TICK_STATUS_COLOR_MAP,
+                                     TREE_STATUS_COLOR_MAP, BehaviorTreeModel,
+                                     QtBTreeItem, create_scene_nodes)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,13 @@ class TreeSnapshot:
 
 
 class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
+    """
+    TODO:
+    - generate nodes
+    - color nodes based on status at each tick
+    - determine how to collapse nodes?
+    - disable delete/add widgets
+    """
     filename = "monitor_page.ui"
 
     tree_view: QtWidgets.QTreeView
@@ -97,6 +107,14 @@ class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
         self.tick_spin_box.valueChanged.connect(
             partial(self.update_display_for_tick, zero_indexed=False)
         )
+        self.auto_arrange_button.clicked.connect(self.auto_arrange_nodes)
+
+    def auto_arrange_nodes(self, *args, **kwargs) -> None:
+        """Auto-arrange the nodes in the node editor using a pygraphviz layout"""
+        try:
+            self.node_editor.scene.auto_arrange(layout="pygraphviz", prog="dot")
+        except ImportError:
+            logger.debug("pygraphviz not available to run auto arrange routine")
 
     def grab_tick(self) -> None:
         """
@@ -168,6 +186,12 @@ class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
                 msg=tick_snapshot.tree_update
             )
 
+        self.update_node_status(tick_num)
+
+        if not self.node_editor.scene.nodes:
+            self.construct_nodes()
+            self.auto_arrange_nodes()
+
     def incrememt_tick(self):
         curr_tick = self.tick_slider.value()
         self.tick_slider.setValue(curr_tick + 1)
@@ -175,3 +199,52 @@ class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
     def decrememt_tick(self):
         curr_tick = self.tick_slider.value()
         self.tick_slider.setValue(curr_tick - 1)
+
+    def construct_nodes(self):
+        """construct nodes based on loaded tree"""
+        if len(self.tick_history) == 0:
+            self.grab_tick()
+
+        tree = self.tick_history[0]
+        create_scene_nodes(self.node_editor.scene, tree.tree_item)
+
+    def update_node_status(self, tick_idx: int):
+        """
+        Update node color to reflect statuses from tick index tick_idx.
+        Color the node backgrounds using STATUS_COLOR_MAP.
+        Node colors are adjusted using each node's style.
+        Updates nodes in place based on uuid reported from server.
+        """
+        if not (0 <= tick_idx < len(self.tick_history)):
+            return
+        tree_item = self.tick_history[tick_idx].tree_item
+        scene = self.node_editor.scene
+
+        if not scene.nodes:
+            return
+
+        for item in tree_item.walk_tree():
+            item_uuid = item.node_id
+            if item_uuid is None:
+                continue
+
+            node: Node = scene.nodes[str(item_uuid)]
+
+            status = item.status
+            # gRPC enums are basically ints, can't isinstance check or use
+            # two different enums as keys in one dict without collisions
+            if item.parent is None:
+                color_name = TREE_STATUS_COLOR_MAP.get(status, 'grey')
+            else:
+                color_name = TICK_STATUS_COLOR_MAP.get(status, 'grey')
+            color_rgb = QColor(color_name).getRgb()
+            # Set NodeStyle colors for visual feedback
+            new_grad_colors = []
+            # replace existing colors, keeping original gradient settings
+            for i, (grad_extent, _) in enumerate(node.style.gradient_colors):
+                rgb = tuple(max(val - 30 * i, 0) for val in color_rgb[:-1])
+                new_grad_colors.append((grad_extent, QColor(*rgb)))
+
+            node.style.gradient_colors = tuple(new_grad_colors)
+            if node.graphics_object:
+                node.graphics_object.update()

--- a/beams/widgets/monitor.py
+++ b/beams/widgets/monitor.py
@@ -1,0 +1,177 @@
+"""
+Widget for viewing the status of a Behavior Tree, updated with information
+from the BEAMS service
+"""
+
+import dataclasses
+import logging
+from datetime import datetime
+from functools import partial
+from typing import List, Optional
+
+from qtpy import QtWidgets
+from qtpynodeeditor import FlowView
+
+from beams.service.remote_calls.behavior_tree_pb2 import (
+    BehaviorTreeUpdateMessage, NodeId)
+from beams.service.rpc_client import RPCClient
+from beams.widgets.core import DesignerDisplay, insert_widget
+from beams.widgets.heartbeat_info import HeartbeatInfo
+from beams.widgets.node_models import create_editor_view
+from beams.widgets.qt_models import BehaviorTreeModel, QtBTreeItem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class TreeSnapshot:
+    """
+    Simple container holding the relevant information for a snapshot of a
+    tree in time.
+    """
+    timestamp: datetime
+    # holds configuration information and the tip node
+    tree_update: BehaviorTreeUpdateMessage
+    # holds node status and identification information for all nodes
+    tree_item: QtBTreeItem
+
+
+class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
+    filename = "monitor_page.ui"
+
+    tree_view: QtWidgets.QTreeView
+
+    # tree info
+    hb_info_placeholder: QtWidgets.QWidget
+    hb_info_widget: Optional[HeartbeatInfo] = None
+
+    # editor view
+    node_widget: QtWidgets.QWidget
+    node_editor: FlowView
+    auto_arrange_button: QtWidgets.QPushButton
+    update_button: QtWidgets.QPushButton
+
+    # history slider
+    next_step_button: QtWidgets.QToolButton
+    prev_step_button: QtWidgets.QToolButton
+    num_counts_label: QtWidgets.QLabel
+    tick_spin_box: QtWidgets.QSpinBox
+    tick_count_label: QtWidgets.QLabel
+    tick_slider: QtWidgets.QSlider
+
+    client: RPCClient
+    tree_id: NodeId
+
+    tick_history: List[TreeSnapshot]
+
+    def __init__(
+        self,
+        *args,
+        tree_id: NodeId,
+        client: Optional[RPCClient] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        if client is None:
+            self.client = RPCClient()
+        else:
+            self.client = client
+
+        self.tree_id = tree_id
+        self.hb_info_widget = None
+        self.tick_history = []
+        self._setup_editor_widget()
+        self._setup_callbacks()
+
+    def _setup_editor_widget(self) -> None:
+        self.node_editor = create_editor_view()
+        insert_widget(self.node_editor, self.node_widget)
+
+    def _setup_callbacks(self) -> None:
+        self.update_button.clicked.connect(self.grab_tick)
+        self.next_step_button.clicked.connect(self.incrememt_tick)
+        self.prev_step_button.clicked.connect(self.decrememt_tick)
+        self.tick_slider.valueChanged.connect(
+            partial(self.update_display_for_tick, zero_indexed=True)
+        )
+        self.tick_spin_box.valueChanged.connect(
+            partial(self.update_display_for_tick, zero_indexed=False)
+        )
+
+    def grab_tick(self) -> None:
+        """
+        Grab and cache tick information.
+        Update the tick label and range
+        """
+        heartbeat = self.client.get_heartbeat()
+        update_msg = [msg for msg in heartbeat.behavior_tree_update
+                      if msg.tree_id == self.tree_id][0]
+        snapshot = TreeSnapshot(
+            timestamp=heartbeat.reply_timestamp.ToDatetime(),
+            tree_update=update_msg,
+            tree_item=QtBTreeItem.from_tree_details(
+                self.client.get_detailed_update(tree_uuid=self.tree_id.uuid)
+            )
+        )
+
+        self.tick_history.append(snapshot)
+        self.update_tick_widget_ranges()
+
+    def update_tick_widget_ranges(self):
+        # update ui elements
+        self.num_counts_label.setText(f"/ {len(self.tick_history)}")
+        self.tick_slider.setRange(0, len(self.tick_history) - 1)
+        self.tick_spin_box.setMaximum(len(self.tick_history))
+        self.tick_spin_box.setMinimum(1)
+
+    def update_display_for_tick(self, tick_num: int, zero_indexed: bool = True) -> None:
+        """
+        tick_num here is indexed on the tick history list
+        tick_slider: 0, len(tick_history)-1
+        tick_spinbox: 1, len(tick_history)
+        """
+        if zero_indexed:
+            spin_tick_num = tick_num + 1
+        else:
+            spin_tick_num = tick_num
+            tick_num -= 1
+
+        if not (0 <= tick_num < len(self.tick_history)):
+            return
+
+        self.tick_slider.blockSignals(True)
+        self.tick_slider.setValue(tick_num)
+        self.tick_slider.blockSignals(False)
+
+        self.tick_spin_box.blockSignals(True)
+        self.tick_spin_box.setValue(spin_tick_num)
+        self.tick_spin_box.blockSignals(False)
+
+        tick_snapshot = self.tick_history[tick_num]
+
+        # update tree view and heartbeat widget
+        self.tree_model = BehaviorTreeModel(
+            tree=tick_snapshot.tree_item
+        )
+        self.tree_view.setModel(self.tree_model)
+        self.tree_view.expandAll()
+
+        if self.hb_info_widget is None:
+            self.hb_info_widget = HeartbeatInfo(
+                tree_update=tick_snapshot.tree_update,
+                timestamp=tick_snapshot.timestamp,
+            )
+            insert_widget(self.hb_info_widget, self.hb_info_placeholder)
+        else:
+            self.hb_info_widget.update_from_msg(
+                timestamp=tick_snapshot.timestamp,
+                msg=tick_snapshot.tree_update
+            )
+
+    def incrememt_tick(self):
+        curr_tick = self.tick_slider.value()
+        self.tick_slider.setValue(curr_tick + 1)
+
+    def decrememt_tick(self):
+        curr_tick = self.tick_slider.value()
+        self.tick_slider.setValue(curr_tick - 1)

--- a/beams/widgets/monitor.py
+++ b/beams/widgets/monitor.py
@@ -186,17 +186,21 @@ class MonitorPage(DesignerDisplay, QtWidgets.QWidget):
                 msg=tick_snapshot.tree_update
             )
 
-        self.update_node_status(tick_num)
-
         if not self.node_editor.scene.nodes:
             self.construct_nodes()
             self.auto_arrange_nodes()
 
+        self.update_node_status(tick_num)
+
     def incrememt_tick(self):
+        if not self.tick_history:
+            return
         curr_tick = self.tick_slider.value()
         self.tick_slider.setValue(curr_tick + 1)
 
     def decrememt_tick(self):
+        if not self.tick_history:
+            return
         curr_tick = self.tick_slider.value()
         self.tick_slider.setValue(curr_tick - 1)
 

--- a/beams/widgets/node_models.py
+++ b/beams/widgets/node_models.py
@@ -120,9 +120,10 @@ class MultiChildNodeModel(NodeDataModel):
 
         self.output_connections = []
 
-    @property
-    def caption(self):
-        return self.name
+        self.caption = self.name
+
+        # give each node a unique style, inherited from NodeDataModel by default
+        self._style = deepcopy(self.style)
 
     def validation_state(self) -> NodeValidationState:
         return self._validation_state
@@ -130,7 +131,7 @@ class MultiChildNodeModel(NodeDataModel):
     def validation_message(self) -> str:
         return self._validation_message
 
-    def set_in_data(self, node_data: BlankNodeData, port: Port):
+    def set_in_data(self, node_data: NodeData, port: Port):
         """
         Callback run when input data is changed.  We hook this to verify
         that there is a valid parent node
@@ -212,12 +213,12 @@ class LeafNodeModel(NodeDataModel):
         self._parent_node = None
         self._validation_state = NodeValidationState.warning
         self._validation_message = "Uninitialized"
+        # give each node a unique style, inherited from NodeDataModel by default
+        self._style = deepcopy(self.style)
 
-    @property
-    def caption(self):
-        return self.name
+        self.caption = self.name
 
-    def set_in_data(self, node_data: BlankNodeData, port: Port):
+    def set_in_data(self, node_data: NodeData, port: Port):
         """
         Callback run when input data is changed.  We hook this to verify
         that there is a valid parent node

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -203,7 +203,7 @@ class QtBTreeItem:
         root_item = QtBTreeItem(
             name=tree.tree_id.name,
             node_id=UUID(tree.tree_id.uuid),
-            node_type="<root>",
+            node_type="",
             status=tree.tree_status,
         )
         root_item.addChild(tree_root_item)

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -27,7 +27,7 @@ STATUS_ICON_MAP = {
     TickStatus.INVALID: "fa5s.minus-circle",
     TickStatus.SUCCESS: "fa5s.check-circle",
     TickStatus.RUNNING: "fa5s.running",
-    TickStatus.FAILURE: "fa5s.times-circlde",
+    TickStatus.FAILURE: "fa5s.times-circle",
 }
 
 

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -1,5 +1,6 @@
 """
-Qt models and items for use across the BEAMS GUI.
+Qt models and items for use across the BEAMS GUI.  Contains TreeViews, Models,
+and other Qt-related classes
 """
 
 from __future__ import annotations
@@ -28,6 +29,20 @@ STATUS_ICON_MAP = {
     TickStatus.SUCCESS: "fa5s.check-circle",
     TickStatus.RUNNING: "fa5s.running",
     TickStatus.FAILURE: "fa5s.times-circle",
+}
+
+TICK_STATUS_COLOR_MAP = {
+    TickStatus.INVALID: "grey",
+    TickStatus.SUCCESS: "green",
+    TickStatus.RUNNING: "orange",
+    TickStatus.FAILURE: "red",
+}
+
+TREE_STATUS_COLOR_MAP = {
+    TreeStatus.ERROR: "red",
+    TreeStatus.IDLE: "grey",
+    TreeStatus.TICKING: "orange",
+    TreeStatus.WAITING_ACK: "magenta",
 }
 
 
@@ -257,7 +272,8 @@ class QtBTreeItem:
     def icon(self):
         """return icon for this item"""
         icon_id = STATUS_ICON_MAP.get(self.status)
-        return qta.icon(icon_id)
+        icon_color = TICK_STATUS_COLOR_MAP.get(self.status)
+        return qta.icon(icon_id, color=icon_color)
 
     def walk_tree(
         self,
@@ -486,6 +502,14 @@ def create_scene_nodes(scene: FlowScene, tree_item: QtBTreeItem) -> None:
             model_name = tree_item.node_type
         model_cls = scene.registry.get_model_by_name(model_name)[0]
         node = scene.create_node(model_cls)
+
+        # hack the scene to use our uids
+        # we do this here while we're matching items to nodes
+        if tree_item.node_id is not None:
+            prev_uid = node.id
+            node._uid = str(tree_item.node_id)
+            scene._nodes.pop(prev_uid)
+            scene._nodes[node.id] = node
 
         for i, child in enumerate(tree_item.children):
             child_node = _inner_create_node(child)

--- a/beams/widgets/qt_models.py
+++ b/beams/widgets/qt_models.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import qtawesome as qta
 from py_trees.common import Status
 from qtpy import QtCore
+from qtpynodeeditor import FlowScene, PortType
 
 from beams.service.remote_calls.behavior_tree_pb2 import (NodeInfo, TickStatus,
                                                           TreeDetails,
@@ -475,3 +476,23 @@ class BehaviorTreeModel(QtCore.QAbstractItemModel):
             return item.icon()
 
         return None
+
+
+def create_scene_nodes(scene: FlowScene, tree_item: QtBTreeItem) -> None:
+    def _inner_create_node(tree_item: QtBTreeItem):
+        if tree_item.node_type == "":
+            model_name = " Root "  # TODO: deal with this spacing issue upstream
+        else:
+            model_name = tree_item.node_type
+        model_cls = scene.registry.get_model_by_name(model_name)[0]
+        node = scene.create_node(model_cls)
+
+        for i, child in enumerate(tree_item.children):
+            child_node = _inner_create_node(child)
+            scene.create_connection(
+                node[PortType.output][i], child_node[PortType.input][0]
+            )
+
+        return node
+
+    _inner_create_node(tree_item)

--- a/beams/widgets/window.py
+++ b/beams/widgets/window.py
@@ -1,18 +1,98 @@
+import datetime
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
-from qtpy.QtWidgets import (QAction, QFileDialog, QMainWindow, QTabWidget,
-                            QWidget)
+import qtawesome as qta
+from grpc import RpcError
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (QAbstractButton, QAction, QDialog,
+                            QDialogButtonBox, QFileDialog, QLabel, QMainWindow,
+                            QPushButton, QTabWidget, QWidget)
 
+from beams.service.remote_calls.behavior_tree_pb2 import (
+    BehaviorTreeUpdateMessage, NodeId)
+from beams.service.rpc_client import RPCClient
 from beams.tree_config import get_tree_item_from_path, save_tree_item_to_path
 from beams.tree_config.base import BehaviorTreeItem
 from beams.widgets.core import DesignerDisplay
 from beams.widgets.edit import EditPage
 from beams.widgets.exception import DefaultExceptionNotifier, install
+from beams.widgets.heartbeat_info import HeartbeatInfo
+from beams.widgets.monitor import MonitorPage
 
 logger = logging.getLogger(__name__)
+
+
+class TreeSelector(DesignerDisplay, QDialog):
+    """
+    Opens a dialog that displays the trees available to connect to.
+
+    Call .open() and after `finished` is emitted, inspect this
+    """
+
+    filename = "tree_selector.ui"
+
+    tab_widget: QTabWidget
+    button_box: QDialogButtonBox
+
+    selected_tree: Optional[Tuple[datetime.datetime, BehaviorTreeUpdateMessage]] = None
+
+    def __init__(
+        self,
+        *args,
+        client: Optional[RPCClient] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        if client is None:
+            self.client = RPCClient.from_config()
+        else:
+            self.client = client
+
+        self.timestamp = datetime.datetime.now()
+
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setIcon(qta.icon("ei.refresh"))
+        self.button_box.addButton(self.refresh_button, QDialogButtonBox.ActionRole)
+
+        self.gather_heartbeats()
+
+        self.button_box.clicked.connect(self.dispatch_clicks)
+
+    def dispatch_clicks(self, button: QAbstractButton):
+        if button is self.refresh_button:
+            self.gather_heartbeats()
+
+    def gather_heartbeats(self) -> None:
+        try:
+            self.heartbeats = self.client.get_heartbeat()
+        except RpcError as ex:
+            raise RuntimeError(
+                "Unable to access service heartbeats, service may be offline "
+                "or the client configuration may be incorrect."
+                f"\n\n{ex.details()}"
+            )
+
+        self.tab_widget.clear()
+        if len(self.heartbeats.behavior_tree_update) == 0:
+            na_label = QLabel("No trees loaded in service")
+            na_label.setAlignment(Qt.AlignCenter)
+            self.tab_widget.insertTab(0, na_label, "N/A")
+
+        self.timestamp = self.heartbeats.reply_timestamp.ToDatetime()
+
+        for update in self.heartbeats.behavior_tree_update:
+            info_widget = HeartbeatInfo(tree_update=update, timestamp=self.timestamp)
+            self.tab_widget.insertTab(0, info_widget, update.tree_id.name)
+
+    def accept(self, *args, **kwargs):
+        curr_widget = self.tab_widget.currentWidget()
+        if isinstance(curr_widget, HeartbeatInfo):
+            self.selected_tree = (self.timestamp, curr_widget.update_msg)
+
+        super().accept(*args, **kwargs)
 
 
 class MainWindow(DesignerDisplay, QMainWindow):
@@ -29,9 +109,13 @@ class MainWindow(DesignerDisplay, QMainWindow):
     action_open_from_service: QAction
     action_config_connnect: QAction
 
+    selector_dialog: Optional[TreeSelector] = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         edit_widget = EditPage()
+
+        self.client = RPCClient.from_config()
 
         self.tab_widget.addTab(edit_widget, "edit")
         self.action_open_file.triggered.connect(self.open_file)
@@ -42,6 +126,8 @@ class MainWindow(DesignerDisplay, QMainWindow):
         self.tab_widget.tabCloseRequested.connect(
             self.tab_widget.removeTab
         )
+
+        self.action_open_from_service.triggered.connect(self.open_from_heartbeat)
 
         # Exception handling: show a dialog to catch exceptions in main qt thread
         install(use_default_handler=False)
@@ -92,6 +178,22 @@ class MainWindow(DesignerDisplay, QMainWindow):
         """
         widget = EditPage(tree=data, full_path=filename)
         self.tab_widget.addTab(widget, self.get_tab_name(filename))
+        curr_idx = self.tab_widget.count() - 1
+        self.tab_widget.setCurrentIndex(curr_idx)
+
+    def _new_monitor_tab(
+        self,
+        tree_id: NodeId
+    ) -> None:
+        """
+        Open a tree in new monitor tab
+
+        Parameters
+        ----------
+        FINISHTHISPLSHeLP
+        """
+        widget = MonitorPage(tree_id=tree_id, client=self.client)
+        self.tab_widget.addTab(widget, self.get_tab_name(tree_id.name))
         curr_idx = self.tab_widget.count() - 1
         self.tab_widget.setCurrentIndex(curr_idx)
 
@@ -172,3 +274,16 @@ class MainWindow(DesignerDisplay, QMainWindow):
             self.tab_widget.currentIndex(),
             self.get_tab_name(filename),
         )
+
+    def open_from_heartbeat(self):
+        if self.selector_dialog is None:
+            self.selector_dialog = TreeSelector(parent=self, client=self.client)
+            self.selector_dialog.finished.connect(self.open_monitor_page)
+        self.selector_dialog.show()
+
+    def open_monitor_page(self):
+        if self.selector_dialog is None:
+            return
+
+        if self.selector_dialog.selected_tree is not None:
+            self._new_monitor_tab(self.selector_dialog.selected_tree[1].tree_id)


### PR DESCRIPTION
## Description
Tossing this up before I forget it exists.

- Adds a monitor page
  - displays node status in the treeview
  - Colors node views in the node editor
    - This required deep-copying each node's stylesheet
  - display the heartbeat information for the selected tree
  - Stores the collected ticks and allows the user to switch between them via a spinbox or slider
- Adds a dialog that examines the current service heartbeat for trees to monitor from the main menu

## Motivation and Context
We want to monitor trees!

Currently this operates on a "polling" model, meaning we have a button that grabs the latest detailed info chunk from the service.  Eventually we probably want to subscribe, but high tick rates makes this a scary prospect. (100 ms tick rate?)

## How Has This Been Tested?
Interactively, and some tests have been added

## Where Has This Been Documented?
This PR

<img width="2288" height="1728" alt="image" src="https://github.com/user-attachments/assets/1960ac06-2554-4b7f-8354-54c9171e48be" />

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
